### PR TITLE
Ss 585 shinyproxy chart and network policies

### DIFF
--- a/scaleout/stackn/templates/network-policies.yaml
+++ b/scaleout/stackn/templates/network-policies.yaml
@@ -48,10 +48,7 @@ spec:
   policyTypes:
   - Egress
   egress:
-  - to:
-    - ipBlock:
-        cidr: {{ .Values.networkPolicy.kubernetes.cidr }}
-    ports:
+  - ports:
     - protocol: TCP
       port: {{ .Values.networkPolicy.kubernetes.port }}
 ---
@@ -285,4 +282,53 @@ spec:
       - namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingress_controller_namespace }} # <- This should allow traffic from ingress namespace
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: {{ .Values.namespace | default "default" }}
+  name: allow-pod-to-shinyproxy
+spec:
+  podSelector:
+    matchLabels:
+      app: shinyproxy-deployment
+  policyTypes:
+    - Egress
+    - Ingress
+  egress:
+  - to:
+    - podSelector:
+        matchExpressions:
+        - key: sp.instance
+          operator: Exists
+  ingress:
+  - from:
+    - podSelector:
+        matchExpressions:
+        - key: sp.instance
+          operator: Exists
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: {{ .Values.namespace | default "default" }}
+  name: allow-shinyproxy-to-pod
+spec:
+  podSelector:
+    matchExpressions:
+    - key: sp.instance
+      operator: Exists
+  policyTypes:
+    - Egress
+    - Ingress
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app: shinyproxy-deployment
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: shinyproxy-deployment
 {{- end }}

--- a/scaleout/stackn/templates/role.yaml
+++ b/scaleout/stackn/templates/role.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 rules:
-  - apiGroups: ["", "apps", "networking.k8s.io", "autoscaling"]
+  - apiGroups: ["", "apps", "networking.k8s.io", "autoscaling","batch"]
     resources: ["*"]
     verbs: ["*"]
 {{- end }}


### PR DESCRIPTION
The PR relates to tasks [SS-559](https://scilifelab.atlassian.net/browse/SS-559) and [SS-585](https://scilifelab.atlassian.net/browse/SS-585). CIDR has been removed from the the allow-api-access policy due to issues with Cilium. Will create an issue for Erik to see if the latest fix by Cilium changes anything. Shiny proxy requires access to pods so all pods created from shinyproxy will be able to communicate via the added Network Policy.