### PR TITLE
added reset_db option to studio deployment and values

### DIFF
--- a/scaleout/stackn/templates/studio-deployment.yaml
+++ b/scaleout/stackn/templates/studio-deployment.yaml
@@ -66,6 +66,8 @@ spec:
         {{ end }}
         - name: INIT
           value: {{ .Values.studio.init | quote }}
+        - name: RESET_DB
+          value: {{ .Values.studio.reset_db | quote }}
         - name: STUDIO_STORAGECLASS
           value: {{ include "stackn.studio.storageclass" . }}
         - name: STUDIO_ACCESSMODE

--- a/scaleout/stackn/values.yaml
+++ b/scaleout/stackn/values.yaml
@@ -55,6 +55,7 @@ studio:
     type: RollingUpdate
   debug: false
   init: true
+  reset_db: false
   enable_project_extra_settings: false
   inactive_users: False
   custom_apps:


### PR DESCRIPTION
[This PR is linked to the one in the stackn repo.](https://github.com/ScilifelabDataCentre/stackn/pull/103)

I've added the `RESET_DB` env variable to the studio deployment. This works just as the `DEBUG` variable. We can override this with Argo. 

