### PR TITLE
SS 868 event listener

### DIFF
--- a/scaleout/stackn/templates/_helper.tpl
+++ b/scaleout/stackn/templates/_helper.tpl
@@ -170,3 +170,28 @@ Return STACKn rabbit secret
 {{- end -}}
 
 
+{{/*
+    Return eventuser password
+    */}}
+    {{- define "stackn.studio.eventuser.password" -}}
+    {{- if .Values.global.studio.eventuserPassword }}
+        {{- .Values.global.studio.eventuserPassword -}}
+    {{- else if .Values.studio.eventuserPassword -}}
+        {{- .Values.studio.eventuserPassword -}}
+    {{- else -}}
+        {{- randAlphaNum 10 -}}
+    {{- end -}}
+    {{- end -}}
+    
+    {{/*
+    Return eventuser email
+    */}}
+    {{- define "stackn.studio.eventuser.email" -}}
+    {{- if .Values.global.studio.eventuserEmail }}
+        {{- .Values.global.studio.eventuserEmail -}}
+    {{- else if .Values.studio.eventuserEmail -}}
+        {{- .Values.studio.eventuserEmail -}}
+    {{- else -}}
+        event_user@test.com
+    {{- end -}}
+    {{- end -}}

--- a/scaleout/stackn/templates/basic-secrets.yaml
+++ b/scaleout/stackn/templates/basic-secrets.yaml
@@ -9,6 +9,7 @@ metadata:
 type: Opaque
 data:
   studio-superuser-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "studio-superuser-password" "providedValues" (list "global.studio.superuserPassword" "studio.superuserPassword") "context" $) }}
+  event-user-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "event-user-password" "providedValues" (list "global.studio.eventuserPassword" "studio.eventuserPassword") "context" $) }}
   rabbit-password:  {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "rabbit-password" "providedValues" (list "rabbit.password") "context" $) }}
   django-secret-key:  {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "django-secret-key" "providedValues" (list "studio.djangoSecret") "length" 50 "strong" true "context" $) }}
   {{ if .Values.studio.emailService.enabled }}

--- a/scaleout/stackn/templates/event-listener-deployment.yaml
+++ b/scaleout/stackn/templates/event-listener-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     name: {{ .Release.Name }}-event-listener
   name: {{ .Release.Name }}-event-listener
 spec:
-  replicas: {{ .Values.celeryWorkers.replicas | default 2 }}
+  replicas: 1
   strategy:
     type: Recreate
   selector:
@@ -33,6 +33,10 @@ spec:
               cpu: "100m"
               memory: "512Mi"
       containers:
+      - name: {{ .Release.Name }}-event-listener
+        image: {{ .Values.eventListener.image }}
+        imagePullPolicy: Always
+        name: {{ .Release.Name }}-event-listener
         {{- if .Values.studio.securityContext.enabled }}
         securityContext:
           runAsUser: {{ .Values.studio.securityContext.runAsUser }}
@@ -45,22 +49,20 @@ spec:
         {{- end }}
         env:
         - name: BASE_URL
-          value: {{ .Release.Name }}-{{ .Values.studio.servicename }}
-          value: 
-        - name: DEBUG
-          value: "false"
-        - name: KUBECONFIG
-          value: {{ .Values.studio.kubeconfig_file | quote }}
+          value: http://{{ .Release.Name }}-{{ .Values.studio.servicename }}:8080
+          - name: DEBUG
+          {{ if .Values.studio.debug }}
+            value: "true"
+          {{ else }}
+            value: "false"
+          {{ end }}
         - name: USERNAME
-          value: {{ include "stackn.studio.superuser" . }}
+          value: {{ include "stackn.studio.superuser" . }}@test.com
         - name: PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ include "stackn.secretName" . }}
               key: studio-superuser-password
-        image: {{ .Values.eventListener.image }}
-        imagePullPolicy: Always
-        name: {{ .Release.Name }}-event-listener
         resources:
           limits:
             cpu: {{ .Values.eventListener.resources.limits.cpu }}

--- a/scaleout/stackn/templates/event-listener-deployment.yaml
+++ b/scaleout/stackn/templates/event-listener-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       initContainers:
         - name: wait-for-studio
           image: busybox:1.28.4
-          command: ['sh', '-c', "until nslookup {{ .Release.Name }}-{{ .Values.studio.servicename }}; do echo waiting for {{ .Release.Name }}-{{ .Values.studio.servicename }} service; sleep 5; done"]
+          command: ['sh', '-c', "until wget --tries=1 --spider {{ .Release.Name }}-{{ .Values.studio.servicename }}:8080/openapi/v1/are-you-there; do echo waiting for {{ .Release.Name }}-{{ .Values.studio.servicename }} service; sleep 5; done"]
           resources:
             limits:
               cpu: "100m"
@@ -50,19 +50,19 @@ spec:
         env:
         - name: BASE_URL
           value: http://{{ .Release.Name }}-{{ .Values.studio.servicename }}:8080
-          - name: DEBUG
-          {{ if .Values.studio.debug }}
-            value: "true"
-          {{ else }}
-            value: "false"
-          {{ end }}
+        - name: DEBUG
+        {{- if .Values.studio.debug }}
+          value: "true"
+        {{- else }}
+          value: "false"
+        {{- end }}
         - name: USERNAME
-          value: {{ include "stackn.studio.superuser" . }}@test.com
+          value: {{ include "stackn.studio.eventuser.email" . }}
         - name: PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ include "stackn.secretName" . }}
-              key: studio-superuser-password
+              key: event-user-password
         resources:
           limits:
             cpu: {{ .Values.eventListener.resources.limits.cpu }}

--- a/scaleout/stackn/templates/event-listener-deployment.yaml
+++ b/scaleout/stackn/templates/event-listener-deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    reloader.stakater.com/auto: "true"
+  labels:
+    name: {{ .Release.Name }}-event-listener
+  name: {{ .Release.Name }}-event-listener
+spec:
+  replicas: {{ .Values.celeryWorkers.replicas | default 2 }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      name: {{ .Release.Name }}-event-listener
+  template:
+    metadata:
+      labels:
+        name: {{ .Release.Name }}-event-listener
+        app: stackn-studio
+        allow-api-access: "true"
+    spec:
+      serviceAccountName: {{ include "common.names.fullname" .}}
+      initContainers:
+        - name: wait-for-studio
+          image: busybox:1.28.4
+          command: ['sh', '-c', "until nslookup {{ .Release.Name }}-{{ .Values.studio.servicename }}; do echo waiting for {{ .Release.Name }}-{{ .Values.studio.servicename }} service; sleep 5; done"]
+          resources:
+            limits:
+              cpu: "100m"
+              memory: "512Mi"
+            requests:
+              cpu: "100m"
+              memory: "512Mi"
+      containers:
+        {{- if .Values.studio.securityContext.enabled }}
+        securityContext:
+          runAsUser: {{ .Values.studio.securityContext.runAsUser }}
+          runAsGroup: {{ .Values.studio.securityContext.runAsGroup }}
+          allowPrivilegeEscalation: {{ .Values.studio.securityContext.allowPrivilegeEscalation }}
+          privileged: {{ .Values.studio.securityContext.privileged }}
+          capabilities:
+            drop:
+              - all
+        {{- end }}
+        env:
+        - name: BASE_URL
+          value: {{ .Release.Name }}-{{ .Values.studio.servicename }}
+          value: 
+        - name: DEBUG
+          value: "false"
+        - name: KUBECONFIG
+          value: {{ .Values.studio.kubeconfig_file | quote }}
+        - name: USERNAME
+          value: {{ include "stackn.studio.superuser" . }}
+        - name: PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: studio-superuser-password
+        image: {{ .Values.eventListener.image }}
+        imagePullPolicy: Always
+        name: {{ .Release.Name }}-event-listener
+        resources:
+          limits:
+            cpu: {{ .Values.eventListener.resources.limits.cpu }}
+            memory: {{ .Values.eventListener.resources.limits.memory }}
+          requests:
+            cpu: {{ .Values.eventListener.resources.requests.cpu }}
+            memory: {{ .Values.eventListener.resources.requests.memory }}
+      imagePullSecrets:
+        - name: ghcrsecret
+      restartPolicy: Always
+      volumes:
+status: {}

--- a/scaleout/stackn/templates/studio-deployment.yaml
+++ b/scaleout/stackn/templates/studio-deployment.yaml
@@ -59,11 +59,11 @@ spec:
         - containerPort: 8080
         env:
         - name: DEBUG
-        {{ if .Values.studio.debug }}
+        {{- if .Values.studio.debug }}
           value: "true"
-        {{ else }}
+        {{- else }}
           value: "false"
-        {{ end }}
+        {{- end }}
         - name: INIT
           value: {{ .Values.studio.init | quote }}
         - name: RESET_DB
@@ -81,6 +81,11 @@ spec:
             secretKeyRef:
               name: {{ include "stackn.secretName" . }}
               key: studio-superuser-password
+        - name: EVENT_USER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: event-user-password
         - name: GET_HOSTS_FROM
           value: dns
         - name: POSTGRES_PASSWORD

--- a/scaleout/stackn/templates/studio-settings-configmap.yaml
+++ b/scaleout/stackn/templates/studio-settings-configmap.yaml
@@ -129,7 +129,7 @@ data:
     REST_FRAMEWORK = {
         "DEFAULT_AUTHENTICATION_CLASSES": ["rest_framework.authentication.TokenAuthentication"],
         "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.NamespaceVersioning",
-        "ALLOWED_VERSIONS": [None, "beta", "v1"],
+        "ALLOWED_VERSIONS": [None, "beta", "v1", "api", "api-v1"],
         "DEFAULT_VERSION": "v1",
         "DEFAULT_RENDERER_CLASSES": ("rest_framework.renderers.JSONRenderer",),
         "DEFAULT_PARSER_CLASSES": ("rest_framework.parsers.JSONParser",),

--- a/scaleout/stackn/values.yaml
+++ b/scaleout/stackn/values.yaml
@@ -87,9 +87,9 @@ studio:
       requests:
         cpu: "100m"
         memory: "256Mi"
-  image: #tell which image to deploy for studio
-    repository: ghcr.io/scilifelabdatacentre/stackn/serve-studio:develop-20230823  #This image can be built from Dockerfile inside stackn/components/studio (https://github.com/scaleoutsystems/stackn)
-    pullPolicy: IfNotPresent # used to ensure that each time we redeploy always pull the latest image
+  image: 
+    repository: ghcr.io/sandstromviktor/studio-dev:v18
+    pullPolicy: IfNotPresent
   resources:
     limits:
       cpu: "1000m"
@@ -269,8 +269,7 @@ reloader:
     watchGlobally: false
 
 eventListener:
-  image: 
-  replicas: 1
+  image: ghcr.io/scilifelabdatacentre/serve-event-listener/event-listener:v0.1.1
   resources:
     requests:
       cpu: "100m"

--- a/scaleout/stackn/values.yaml
+++ b/scaleout/stackn/values.yaml
@@ -267,3 +267,14 @@ reloader:
   namespace: default
   reloader:
     watchGlobally: false
+
+eventListener:
+  image: 
+  replicas: 1
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "1Gi"
+    limits:
+      cpu: "500m"
+      memory: "2Gi"

--- a/scaleout/stackn/values.yaml
+++ b/scaleout/stackn/values.yaml
@@ -272,7 +272,7 @@ reloader:
     watchGlobally: false
 
 eventListener:
-  image: ghcr.io/scilifelabdatacentre/serve-event-listener/event-listener:v0.1.1
+  image: ghcr.io/scilifelabdatacentre/serve-event-listener/event-listener:v0.1.3
   resources:
     requests:
       cpu: "100m"

--- a/scaleout/stackn/values.yaml
+++ b/scaleout/stackn/values.yaml
@@ -78,7 +78,7 @@ studio:
     replicas: 1
     strategy:
       type: Recreate
-    image: ghcr.io/scilifelabdatacentre/stackn/serve-ingress:develop-20230823 
+    image: ghcr.io/scilifelabdatacentre/stackn/serve-ingress:develop-20240130
     pullPolicy: IfNotPresent
     resources:
       limits:
@@ -88,7 +88,7 @@ studio:
         cpu: "100m"
         memory: "256Mi"
   image: 
-    repository: ghcr.io/sandstromviktor/studio-dev:v18
+    repository: ghcr.io/scilifelabdatacentre/stackn/serve-studio:develop-20240130
     pullPolicy: IfNotPresent
   resources:
     limits:
@@ -110,6 +110,9 @@ studio:
   superUser: admin
   superuserPassword: ""
   superuserEmail: admin@test.com
+  eventUser: ""
+  eventuserPassword: ""
+  eventuserEmail: ""
   version: studio
   securityContext:
     enabled: true


### PR DESCRIPTION
# Description 

This PR is closely linked to [#127](https://github.com/ScilifelabDataCentre/stackn/pull/127) in the stackn repo, and [#39](https://github.com/ScilifelabDataCentre/argocd-team-whale/pull/39) in the ArgoCD repo

I've updated the charts with a deployment for the event-listener. I've also added a new admin user called `event_user` to handle the status updates. (this is in PR [#127](https://github.com/ScilifelabDataCentre/stackn/pull/127))

When studio is starting up, this user is created and it fetches the env variable `EVENT_USER_PASSWORD` to set the password. This variable is defined in `basic-secrets.yaml` and is randomly generated. 

This password is then mounted into the event-listener pod as `PASSWORD`. 

# What to test
1. First of all, make sure that the pod starts up as expected. I've implemented an init container that checks if the API is ready.
2. Check that the statuses are correct
3. Any suggestions to implement probes into this?

# Next
If this is approved, we must update the ARGO repo to make sure that we set the correct configs