### PR TITLE
Add new fields for additional shinyproxy settings

### DIFF
--- a/apps/shinyproxy/Chart.yaml
+++ b/apps/shinyproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: shinyproxy
 description: A Helm chart to install Shinyproxy
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "0.1"
 maintainers:
   - name: Team Whale

--- a/apps/shinyproxy/templates/configmap.yaml
+++ b/apps/shinyproxy/templates/configmap.yaml
@@ -14,8 +14,9 @@ data:
     proxy:
       authentication: none
       container-backend: kubernetes
-      heartbeat-rate: 10000
-      heartbeat-timeout: 60000
+      heartbeat-rate: {{ .Values.appconfig.proxyheartbeatrate | default 10000 }}
+      heartbeat-timeout: {{ .Values.appconfig.proxyheartbeattimeout | default 60000 }}
+      container-wait-time: {{ .Values.appconfig.proxycontainerwaittime | default 30000 }}
       kubernetes:
         internal-networking: true
         namespace: {{ .Release.Namespace }}
@@ -37,8 +38,8 @@ data:
         container-memory-request: {{ .Values.flavor.requests.memory }}
         port: {{ .Values.appconfig.port }}
         id:  {{ .Release.Name }}
-        display-name: {{ .Values.app_name }}
-        description: {{ .Values.app_description }}
+        display-name: {{ .Values.app_name | quote }}
+        description: {{ .Values.app_description | quote }}
         labels:
           sp.instance: {{ .Release.Name }}
           allow-internet-egress: "true"


### PR DESCRIPTION
In this PR I am changing some settings of shinyproxy deployments so that they pick up parameters passed from the main Serve app if these parameters were set there. In addition, wrapping the app name and description into quotation marks in order to solve a bug - [SS-962](https://scilifelab.atlassian.net/browse/SS-962).
Upping the helm chart version to 1.1.0.