### PR TITLE
Bugfix/disable ipv6 for shiny

### DIFF
--- a/apps/shiny/Chart.yaml
+++ b/apps/shiny/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart Shiny apps
 name: shinyapp
-version: 1.0.1
+version: 1.0.2
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se

--- a/apps/shiny/templates/deployment.yaml
+++ b/apps/shiny/templates/deployment.yaml
@@ -44,5 +44,16 @@ spec:
           {{- toYaml .Values.flavor | nindent 10 }}
         ports:
           - containerPort: {{ .Values.appconfig.port }}
+        volumeMounts:
+        - name: {{ .Release.Name }}-shiny-configmap
+          mountPath: /etc/shiny-server/shiny-server.conf
+          subPath: shiny-server.conf
       terminationGracePeriodSeconds: 30
       dnsPolicy: ClusterFirst
+      volumes:
+      - name: {{ .Release.Name }}-shiny-configmap
+        configMap:
+          name: {{ .Release.Name }}-shiny-configmap
+          items:
+          - key: shiny-server.conf
+            path: shiny-server.conf

--- a/apps/shiny/templates/shiny-configmap.yaml
+++ b/apps/shiny/templates/shiny-configmap.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-shiny-configmap
+  namespace: {{ .Release.Namespace }}
+data:
+  shiny-server.conf: |-
+    # Instruct Shiny Server to run applications as the user "shiny"
+    run_as shiny;
+    http_keepalive_timeout 600;
+    # Define a server that listens on user defined port
+    server {
+      listen {{ .Values.appconfig.port }} 0.0.0.0;
+      # Define a location at the base URL
+      location / {
+
+        # Host the directory of Shiny Apps stored in this directory
+        site_dir /srv/shiny-server;
+
+        # Log all Shiny output to files in this directory
+        log_dir /var/log/shiny-server;
+
+        # When a user visits the base URL rather than a particular application,
+        # an index of the applications available in this directory will be shown.
+        directory_index on;
+        app_init_timeout 600;
+        app_idle_timeout 600;
+      }
+      app_init_timeout 600;
+      app_idle_timeout 600;
+    }


### PR DESCRIPTION
IPV6 is disabled on the new cluster. To make shiny apps work, the need to be explicitly set so that they bind to ipv4 addresses. The change will  create a configmap for each shiny app and then mount it into the pod so that it overrides the config located at /etc/shiny-server/shiny-server.conf.