### PR TITLE
Changed Shiny proxy default seat configurations

### DIFF
--- a/apps/shinyproxy/Chart.yaml
+++ b/apps/shinyproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: shinyproxy
 description: A Helm chart to install Shinyproxy
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: "0.1"
 maintainers:
   - name: Team Whale

--- a/apps/shinyproxy/values.yaml
+++ b/apps/shinyproxy/values.yaml
@@ -9,9 +9,9 @@ appconfig:
   port: 3838
   image:
   path: /home
-  minimumSeatsAvailable: 2
-  seatsPerContainer: 3
-  allowContainerReuse: true
+  minimumSeatsAvailable: 1
+  seatsPerContainer: 1
+  allowContainerReuse: false
 
 
 global:


### PR DESCRIPTION
Changed the default configuration settings of Shiny proxy app types.

* minimum-seats-available default 1
* seats-per-container default 1
* allow-container-re-use default False (the container cannot be reused by a new user)
