### PR TITLE
App status related changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,8 +133,11 @@ static/open-iconic/
 
 repos/
 
+# Downloaded charts
+/tmpcharts
+serve/charts/*.tgz
+
 #Other
 values-local*
 
-/tmpcharts
 requirements.lock

--- a/serve/templates/studio-settings-configmap.yaml
+++ b/serve/templates/studio-settings-configmap.yaml
@@ -373,7 +373,7 @@ data:
     # App statuses
     APPS_STATUS_SUCCESS = ['Running', 'Succeeded', 'Success']
     APPS_STATUS_WARNING = ['Pending', 'Installed',
-                        'Waiting', 'Installing', 'Created']
+                        'Waiting', 'Installing', 'Created', 'Creating']
 
     DOMAIN = {{ .Values.domain | quote }}
     AUTH_DOMAIN = '{{ .Release.Name }}-studio.{{ .Values.namespace | default "default" }}.svc.{{ .Values.cluster_domain | default "cluster.local"}}'

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -270,7 +270,7 @@ reloader:
     watchGlobally: false
 
 eventListener:
-  image: ghcr.io/scilifelabdatacentre/serve-event-listener/event-listener:v0.1.7
+  image: ghcr.io/scilifelabdatacentre/serve-event-listener/event-listener:v0.1.8
   resources:
     requests:
       cpu: "100m"

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -270,7 +270,7 @@ reloader:
     watchGlobally: false
 
 eventListener:
-  image: ghcr.io/scilifelabdatacentre/serve-event-listener/event-listener:v0.1.5
+  image: ghcr.io/scilifelabdatacentre/serve-event-listener/event-listener:v0.1.7
   resources:
     requests:
       cpu: "100m"


### PR DESCRIPTION
This PR makes the same changes in serve-charts as already made in the serve repository. It adds the app status Creating to the app status group Warning so it is no longer displayed as the default class style danger. It also upgrades the event listener to version 0.1.8.