### PR TITLE
Correct LOGIN_REDIRECT_URL

### DIFF
--- a/serve/templates/studio-settings-configmap.yaml
+++ b/serve/templates/studio-settings-configmap.yaml
@@ -330,7 +330,7 @@ data:
     MEDIA_ROOT = os.path.join(BASE_DIR, 'media/')
 
     # Related to user registration and authetication workflow
-    LOGIN_REDIRECT_URL = '/projects'
+    LOGIN_REDIRECT_URL = '/projects/'
     LOGIN_URL = 'login'
     LOGOUT_URL = 'logout'
     INACTIVE_USERS = {{ if .Values.studio.inactive_users }}True{{ else }}False{{ end }}


### PR DESCRIPTION
This PR is a companion of [PR #233](https://github.com/ScilifelabDataCentre/serve/pull/233) in the Serve repo. The redirect URL after login was incorrect, it needed a slash afterwards. Corrected here.