### PR TITLE
SS-342 and SS-1167 allow custom commands for custom apps

### DIFF
--- a/apps/custom-app/Chart.yaml
+++ b/apps/custom-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart for a standard serve app
 name: custom-app
-version: 1.0.2
+version: 1.1.0
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se

--- a/apps/custom-app/templates/deployment.yaml
+++ b/apps/custom-app/templates/deployment.yaml
@@ -34,8 +34,10 @@ spec:
           type: RuntimeDefault
         fsGroup: {{ .Values.appconfig.userid | default 1000 }}
 
-      {{- if .Values.apps.volumeK8s }}
+      {{- if or .Values.apps.volumeK8s .Values.appconfig.startupCommand }}
       initContainers:
+      {{- end}}
+      {{- if .Values.apps.volumeK8s }}
       - name: copy-to-pvc
         image: {{ .Values.appconfig.image }}
         imagePullPolicy: IfNotPresent
@@ -55,6 +57,19 @@ spec:
         - name: {{ $key }}
           mountPath: /tmp
       {{- end }}
+      {{- if .Values.appconfig.startupCommand}}
+      - name: create-startup-script
+        image: busybox
+        command:
+          - /bin/sh
+          - -c
+          - |
+            echo "{{ .Values.appconfig.startupCommand }}" > /scripts/custom-start-script.sh;
+            chmod +x /scripts/custom-start-script.sh;
+        volumeMounts:
+          - name: startup-script
+            mountPath: /scripts
+      {{- end}}
       {{- end }}
       containers:
       - name: {{ .Values.appname }}
@@ -63,7 +78,12 @@ spec:
         command:
           - /bin/sh
           - -c
+          {{- if .Values.appconfig.startupCommand }}
+          - /scripts/custom-start-script.sh;
+          {{- else }}
           - ./start-script.sh;
+          {{- end }}
+
         ports:
           - containerPort: {{ .Values.appconfig.port }}
         securityContext:
@@ -93,4 +113,8 @@ spec:
         persistentVolumeClaim:
           claimName: {{ $value.release }}
       {{- end }}
+      {{- if .Values.appconfig.startupCommand}}
+        - name: startup-script
+          emptyDir: { }
+      {{- end}}
       {{ end }}

--- a/apps/custom-app/templates/deployment.yaml
+++ b/apps/custom-app/templates/deployment.yaml
@@ -56,6 +56,7 @@ spec:
         {{- range $key, $value := .Values.apps.volumeK8s }}
         - name: {{ $key }}
           mountPath: /tmp
+        {{- end }}
       {{- end }}
       {{- if .Values.appconfig.startupCommand}}
       - name: create-startup-script
@@ -70,7 +71,6 @@ spec:
           - name: startup-script
             mountPath: /scripts
       {{- end}}
-      {{- end }}
       containers:
       - name: {{ .Values.appname }}
         image: {{ .Values.appconfig.image }}
@@ -97,24 +97,32 @@ spec:
               - all
         resources:
           {{- toYaml .Values.flavor | nindent 10 }}
-        {{- if .Values.apps.volumeK8s }}
+        {{- if or .Values.appconfig.startupCommand .Values.apps.volumeK8s }}
         volumeMounts:
+        {{- end }}
+        {{- if .Values.apps.volumeK8s }}
         {{- range $key, $value := .Values.apps.volumeK8s }}
         - name: {{ $key }}
           mountPath: {{ $.Values.appconfig.path }}
         {{- end }}
         {{- end }}
+        {{- if .Values.appconfig.startupCommand}}
+        - name: startup-script
+          mountPath: /scripts
+        {{- end}}
       terminationGracePeriodSeconds: 30
       dnsPolicy: ClusterFirst
-      {{ if .Values.apps.volumeK8s }}
+      {{ if or .Values.apps.volumeK8s .Values.appconfig.startupCommand }}
       volumes:
+      {{- end }}
+      {{ if .Values.apps.volumeK8s }}
       {{- range $key, $value := .Values.apps.volumeK8s }}
       - name: {{ $key }}
         persistentVolumeClaim:
           claimName: {{ $value.release }}
       {{- end }}
-      {{- if .Values.appconfig.startupCommand}}
-        - name: startup-script
-          emptyDir: { }
-      {{- end}}
       {{ end }}
+      {{- if .Values.appconfig.startupCommand}}
+      - name: startup-script
+        emptyDir: { }
+      {{- end}}

--- a/apps/custom-app/values.yaml
+++ b/apps/custom-app/values.yaml
@@ -17,6 +17,7 @@ appconfig:
   port: 8501
   image: ghcr.io/scilifelabdatacentre/example-streamlit:240312-1531
   path: /home
+  startupCommand: {}
 
 service:
   name: customapp-svc


### PR DESCRIPTION
SS-342 and SS-1167 allow custom commands for custom apps

This is a draft idea that would allow us to use custom apps as basis for even more app types. We'd just be providing via `values` file commands that we'd want to run.

This would solve issues related to gradio and streamlit