### PR TITLE
SS-698 set default timezone to Stockholm time

### DIFF
--- a/serve/templates/studio-settings-configmap.yaml
+++ b/serve/templates/studio-settings-configmap.yaml
@@ -318,7 +318,7 @@ data:
     # Internationalization
     # https://docs.djangoproject.com/en/2.2/topics/i18n/
     LANGUAGE_CODE = 'en-us'
-    TIME_ZONE = 'UTC'
+    TIME_ZONE = 'Europe/Stockholm'
     USE_I18N = True
 
     # Media Files for Studio apps


### PR DESCRIPTION
Source: https://scilifelab.atlassian.net/browse/SS-698

Set default time zone to Stockholm time.
Mention it as tooltip info besides app info in /projects page.