### PR TITLE
Display correct app name for shinyproxy apps

### DIFF
--- a/apps/shinyproxy/templates/configmap.yaml
+++ b/apps/shinyproxy/templates/configmap.yaml
@@ -38,7 +38,7 @@ data:
         container-memory-request: {{ .Values.flavor.requests.memory }}
         port: {{ .Values.appconfig.port }}
         id:  {{ .Release.Name }}
-        display-name: {{ .Values.app_name | quote }}
+        display-name: {{ .Values.name | quote }}
         description: {{ .Values.app_description | quote }}
         minimum-seats-available: {{ .Values.appconfig.minimumSeatsAvailable }}
         seats-per-container: {{ .Values.appconfig.seatsPerContainer }}

--- a/apps/shinyproxy/values.yaml
+++ b/apps/shinyproxy/values.yaml
@@ -1,4 +1,5 @@
 appname: shinyapp
+name: shinyapp
 project:
   name: project
   slug: project-slug


### PR DESCRIPTION
We used a wrong keyword for app name of Shiny apps deployed through Shinyproxy. Now corrected.
This solves issue [SS-1271](https://scilifelab.atlassian.net/browse/SS-1271). 