### PR TITLE
SS-1326 Specify an upload size for Serve apps

### DIFF
--- a/apps/custom-app/Chart.yaml
+++ b/apps/custom-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart for a standard serve app
 name: custom-app
-version: 1.1.1
+version: 1.1.2
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se

--- a/apps/custom-app/templates/ingress.yaml
+++ b/apps/custom-app/templates/ingress.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- end }}
     nginx.ingress.kubernetes.io/custom-http-errors: "503"
     nginx.ingress.kubernetes.io/default-backend: nginx-errors
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ .Values.ingress.clientMaxBodySize }}"
 spec:
   rules:
     - host: {{ .Release.Name }}.{{ .Values.global.domain }}

--- a/apps/custom-app/values.yaml
+++ b/apps/custom-app/values.yaml
@@ -25,6 +25,7 @@ service:
 
 ingress:
   secretName: prod-ingress
+  clientMaxBodySize: 100M
 
 podSecurityContext:
   seccompProfile:

--- a/apps/dash/Chart.yaml
+++ b/apps/dash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart Dash apps
 name: dash-app
-version: 1.0.3
+version: 1.0.4
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se

--- a/apps/dash/templates/ingress.yaml
+++ b/apps/dash/templates/ingress.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- end }}
     nginx.ingress.kubernetes.io/custom-http-errors: "503"
     nginx.ingress.kubernetes.io/default-backend: nginx-errors
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ .Values.ingress.clientMaxBodySize }}"
 spec:
   rules:
     - host: {{ .Release.Name }}.{{ .Values.global.domain }}

--- a/apps/dash/values.yaml
+++ b/apps/dash/values.yaml
@@ -20,6 +20,7 @@ service:
 
 ingress:
   secretName: prod-ingress
+  clientMaxBodySize: 100M
 
 podSecurityContext:
   seccompProfile:

--- a/apps/filemanager/Chart.yaml
+++ b/apps/filemanager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart for the serve File Manager
 name: filemanager
-version: 1.0.3
+version: 1.0.4
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se

--- a/apps/filemanager/templates/ingress.yaml
+++ b/apps/filemanager/templates/ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: "10000M"
     {{- if  ne .Values.permission "public" }}
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.global.domain }}/accounts/login/?next=$scheme%3A%2F%2F$host"

--- a/apps/filemanager/templates/ingress.yaml
+++ b/apps/filemanager/templates/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- end }}
     nginx.ingress.kubernetes.io/custom-http-errors: "503"
     nginx.ingress.kubernetes.io/default-backend: nginx-errors
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ .Values.ingress.clientMaxBodySize }}"
   name: {{ .Release.Name }}-filemanager-ingress
   namespace: {{ .Release.Namespace }}
 spec:

--- a/apps/filemanager/values.yaml
+++ b/apps/filemanager/values.yaml
@@ -12,7 +12,7 @@ global:
 
 ingress:
   secretName: prod-ingress
-  clientMaxBodySize: 100M
+  clientMaxBodySize: 10000M
 
 apps:
   volumeK8s: {}

--- a/apps/filemanager/values.yaml
+++ b/apps/filemanager/values.yaml
@@ -12,6 +12,7 @@ global:
 
 ingress:
   secretName: prod-ingress
+  clientMaxBodySize: 100M
 
 apps:
   volumeK8s: {}

--- a/apps/jupyter-lab/Chart.yaml
+++ b/apps/jupyter-lab/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart for Jupyter Lab
 name: lab
-version: 1.0.4
+version: 1.0.5
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se

--- a/apps/jupyter-lab/templates/ingress.yaml
+++ b/apps/jupyter-lab/templates/ingress.yaml
@@ -13,6 +13,7 @@ metadata:
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
     nginx.ingress.kubernetes.io/custom-http-errors: "503"
     nginx.ingress.kubernetes.io/default-backend: nginx-errors
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ .Values.ingress.clientMaxBodySize }}"
 spec:
   rules:
     - host: {{ .Release.Name }}.{{ .Values.global.domain }}

--- a/apps/jupyter-lab/templates/ingress.yaml
+++ b/apps/jupyter-lab/templates/ingress.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     io.kompose.service: {{ .Release.Name }}-ingress
   annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: "5500m"
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.global.domain }}/accounts/login/?next=$scheme%3A%2F%2F$host"
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host

--- a/apps/jupyter-lab/values.yaml
+++ b/apps/jupyter-lab/values.yaml
@@ -35,6 +35,7 @@ service:
 ingress:
   v1beta1: false
   secretName: prod-ingress
+  clientMaxBodySize: 100M
 
 mlflow:
   url: ""

--- a/apps/jupyter-lab/values.yaml
+++ b/apps/jupyter-lab/values.yaml
@@ -35,7 +35,7 @@ service:
 ingress:
   v1beta1: false
   secretName: prod-ingress
-  clientMaxBodySize: 100M
+  clientMaxBodySize: 5500m
 
 mlflow:
   url: ""

--- a/apps/rstudio/Chart.yaml
+++ b/apps/rstudio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart for RStudio in the browser
 name: rstudio
-version: 1.0.3
+version: 1.0.4
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se

--- a/apps/rstudio/templates/ingress.yaml
+++ b/apps/rstudio/templates/ingress.yaml
@@ -12,6 +12,7 @@ metadata:
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
     nginx.ingress.kubernetes.io/custom-http-errors: "503"
     nginx.ingress.kubernetes.io/default-backend: nginx-errors
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ .Values.ingress.clientMaxBodySize }}"
 spec:
   rules:
     - host: {{ .Release.Name }}.{{ .Values.global.domain }}

--- a/apps/rstudio/values.yaml
+++ b/apps/rstudio/values.yaml
@@ -22,6 +22,7 @@ service:
 ingress:
   v1beta1: false
   secretName: prod-ingress
+  clientMaxBodySize: 100M
 
 podSecurityContext:
   fsGroup: 1000

--- a/apps/shiny/Chart.yaml
+++ b/apps/shiny/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart Shiny apps
 name: shinyapp
-version: 1.0.4
+version: 1.0.5
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se

--- a/apps/shiny/templates/ingress.yaml
+++ b/apps/shiny/templates/ingress.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- end }}
     nginx.ingress.kubernetes.io/custom-http-errors: "503"
     nginx.ingress.kubernetes.io/default-backend: nginx-errors
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ .Values.ingress.clientMaxBodySize }}"
 spec:
   rules:
     - host: {{ .Release.Name }}.{{ .Values.global.domain }}

--- a/apps/shiny/values.yaml
+++ b/apps/shiny/values.yaml
@@ -21,6 +21,7 @@ service:
 
 ingress:
   secretName: prod-ingress
+  clientMaxBodySize: 100M
 
 podSecurityContext:
   seccompProfile:

--- a/apps/shinyproxy/Chart.yaml
+++ b/apps/shinyproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: shinyproxy
 description: A Helm chart to install Shinyproxy
 type: application
-version: 1.4.3
+version: 1.4.4
 appVersion: "0.1"
 maintainers:
   - name: Team Whale

--- a/apps/shinyproxy/templates/ingress.yaml
+++ b/apps/shinyproxy/templates/ingress.yaml
@@ -10,7 +10,6 @@ metadata:
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.global.domain }}/accounts/login/?next=$scheme%3A%2F%2F$host"
     {{- end }}
-    nginx.ingress.kubernetes.io/proxy-body-size: 2000m
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
     nginx.ingress.kubernetes.io/custom-http-errors: "503"
     nginx.ingress.kubernetes.io/default-backend: nginx-errors

--- a/apps/shinyproxy/templates/ingress.yaml
+++ b/apps/shinyproxy/templates/ingress.yaml
@@ -14,6 +14,7 @@ metadata:
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
     nginx.ingress.kubernetes.io/custom-http-errors: "503"
     nginx.ingress.kubernetes.io/default-backend: nginx-errors
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ .Values.ingress.clientMaxBodySize }}"
 spec:
   rules:
     - host: {{ .Release.Name }}.{{ .Values.global.domain }}

--- a/apps/shinyproxy/values.yaml
+++ b/apps/shinyproxy/values.yaml
@@ -27,6 +27,7 @@ service:
 
 ingress:
   secretName: prod-ingress
+  clientMaxBodySize: 100M
 
 s3sync:
   image: scaleoutsystems/s3-sync:latest

--- a/apps/shinyproxy/values.yaml
+++ b/apps/shinyproxy/values.yaml
@@ -27,7 +27,7 @@ service:
 
 ingress:
   secretName: prod-ingress
-  clientMaxBodySize: 100M
+  clientMaxBodySize: 2000M
 
 s3sync:
   image: scaleoutsystems/s3-sync:latest

--- a/apps/tensorflow-serve/chart/Chart.yaml
+++ b/apps/tensorflow-serve/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart for Scaleout Tensorflow Serving Deployment
 name: tensorflow serving
-version: 0.1.0
+version: 0.1.1

--- a/apps/tensorflow-serve/chart/templates/nginx_conf.yaml
+++ b/apps/tensorflow-serve/chart/templates/nginx_conf.yaml
@@ -12,7 +12,7 @@ data:
     http {
         server {
             listen 1234;
-            client_max_body_size 500M;
+            client_max_body_size {{ .Values.nginx.clientMaxBodySize }};
             large_client_header_buffers 4 128k;
 
             location / {

--- a/apps/tensorflow-serve/chart/values.yaml
+++ b/apps/tensorflow-serve/chart/values.yaml
@@ -41,6 +41,7 @@ model_card:
   path: model-card
 
 ingress:
+  clientMaxBodySize: 500M
 
 podSecurityContext:
   seccompProfile:

--- a/apps/tissuumaps/Chart.yaml
+++ b/apps/tissuumaps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart tissuumaps apps
 name: tissuumaps
-version: 1.0.3
+version: 1.0.4
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se

--- a/apps/tissuumaps/templates/ingress.yaml
+++ b/apps/tissuumaps/templates/ingress.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- end }}
     nginx.ingress.kubernetes.io/custom-http-errors: "503"
     nginx.ingress.kubernetes.io/default-backend: nginx-errors
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ .Values.ingress.clientMaxBodySize }}"
 spec:
   rules:
     - host: {{ .Release.Name }}.{{ .Values.global.domain }}

--- a/apps/tissuumaps/values.yaml
+++ b/apps/tissuumaps/values.yaml
@@ -23,6 +23,7 @@ service:
 
 ingress:
   secretName: prod-ingress
+  clientMaxBodySize: 100M
 
 podSecurityContext:
   seccompProfile:

--- a/apps/vscode/Chart.yaml
+++ b/apps/vscode/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart for VS code in the browser
 name: vscode
-version: 1.0.2
+version: 1.0.3
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se

--- a/apps/vscode/templates/ingress.yaml
+++ b/apps/vscode/templates/ingress.yaml
@@ -12,6 +12,7 @@ metadata:
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
     nginx.ingress.kubernetes.io/custom-http-errors: "503"
     nginx.ingress.kubernetes.io/default-backend: nginx-errors
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ .Values.ingress.clientMaxBodySize }}"
 spec:
   rules:
     - host: {{ .Release.Name }}.{{ .Values.global.domain }}

--- a/apps/vscode/values.yaml
+++ b/apps/vscode/values.yaml
@@ -33,6 +33,7 @@ service:
 ingress:
   v1beta1: false
   secretName: prod-ingress
+  clientMaxBodySize: 100M
 
 podSecurityContext:
   seccompProfile:


### PR DESCRIPTION
Set an upload size limit of 100M to Serve apps. Currently when it is not set, the limit will default to 1MB.