### PR TITLE
SS-1017 Enforce secure Postgres connection

### DIFF
--- a/serve/templates/postgres-cert-issuer.yaml
+++ b/serve/templates/postgres-cert-issuer.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-dev
+  namespace: {{ .Values.namespace }}
+spec:
+  acme:
+    email: "email@example.com"
+    server: "https://acme-v02.api.letsencrypt.org/directory"
+    privateKeySecretRef:
+      name: letsencrypt-dev-key
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/serve/templates/postgres-cert.yaml
+++ b/serve/templates/postgres-cert.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: postgres-tls
+  namespace: {{ .Values.namespace }}
+spec:
+  secretName: postgres-tls-secret
+  issuerRef:
+    name: letsencrypt-dev
+    kind: Issuer
+  dnsNames:
+    - studio-postgres # Service name
+  duration: 2160h  # 90 days
+  renewBefore: 360h  # Renew 15 days before expiry

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -211,6 +211,23 @@ postgresql:
       accessModes:
         - *access_mode
       storageClass: *storage_class
+    extraEnvVars:
+      - name: POSTGRES_SSL_CERT
+        value: "/var/lib/postgresql/tls/tls.crt"
+      - name: POSTGRES_SSL_KEY
+        value: "/var/lib/postgresql/tls/tls.key"
+      - name: POSTGRES_SSL_CA
+        value: "/var/lib/postgresql/tls/ca.crt"
+      - name: POSTGRES_SSL_MODE
+        value: "require"
+    extraVolumes:
+      - name: postgres-tls
+        secret:
+          secretName: postgres-tls-secret
+    extraVolumeMounts:
+      - name: postgres-tls
+        mountPath: /var/lib/postgresql/tls
+        readOnly: true
     podLabels: {"app":"stackn-studio"}
 
 redis:


### PR DESCRIPTION
Changes to issue a self-renewable certificate and secret key using K8s Cert Manager and Let's Encrypt.
Refer to the certificate on the Postgres container volume.
Further changes to be done on the Django side.