### PR TITLE
Assigning group-specific permissions and enforcing umask 007

### DIFF
--- a/apps/vscode/templates/deployment.yaml
+++ b/apps/vscode/templates/deployment.yaml
@@ -37,12 +37,13 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - name: vscode
-        image: {{ .Values.appconfig.image }} #TODO add own image here when we have it -  2023-09-28
+        image: {{ .Values.appconfig.image }} #TODO add own image here when we have it -  2023-09-28, # done 2025-03-27
         imagePullPolicy: IfNotPresent
-        command:
-          - /bin/bash
-          - -c
-          - code-server --auth=none --bind-addr 0.0.0.0:8080
+        command: ["/bin/bash"]  # Override default entrypoint
+        args:
+          - "-l"               # Force login shell (sources /etc/profile, for enforcing umask 007 in custom_umask.sh)
+          - "-c"               # Execute the command below,
+          - "umask 007 && exec /usr/bin/code-server --auth=none --bind-addr=0.0.0.0:8080 /home/serve/"
         ports:
           - containerPort: {{ .Values.service.targetport }}
         securityContext:

--- a/apps/vscode/values.yaml
+++ b/apps/vscode/values.yaml
@@ -13,7 +13,7 @@ apps:
   volumek8s:
 
 appconfig:
-  image: ghcr.io/scilifelabdatacentre/serve-vscode:250312-1210
+  image: ghcr.io/scilifelabdatacentre/serve-vscode:latest
 
 affinity:
   nodeAffinity:
@@ -42,7 +42,6 @@ podSecurityContext:
 
 securityContext:
   runAsNonRoot: true
-  runAsUser: 1000
   runAsGroup: 1000
   allowPrivilegeEscalation: false
   privileged: false


### PR DESCRIPTION
Change the VS code permission to group only.

See:

https://scilifelab.atlassian.net/browse/SS-1235
and,
https://scilifelab.atlassian.net/browse/SS-1399