### PR TITLE
SS-1357 restrict admin route access

### DIFF
--- a/serve/templates/basic-secrets.yaml
+++ b/serve/templates/basic-secrets.yaml
@@ -17,5 +17,7 @@ data:
   email-host-password: {{ .Values.studio.emailService.hostPassword | b64enc }}
   #email-api-key: {{ .Values.studio.emailService.apiKey | b64enc }}
   {{ end }}
+  {{ if .Values.studio.githubApiToken }}
   github-api-token: {{ .Values.studio.githubApiToken | b64enc }}
+  {{ end }}
 {{- end -}}

--- a/serve/templates/ingress-platform.yaml
+++ b/serve/templates/ingress-platform.yaml
@@ -56,8 +56,8 @@ spec:
                 number: 8081
           pathType: ImplementationSpecific
   {{- end }}
+{{if ne .Values.environment "local" }}
 ---
-{{if neq .Values.environment "local" }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/serve/templates/ingress-platform.yaml
+++ b/serve/templates/ingress-platform.yaml
@@ -78,7 +78,7 @@ spec:
                 name: {{ .Release.Name }}-studio
                 port:
                   number: 8080
-            path: {{ .Values.studio.adminPath }}
+            path: {{ .Values.studio.djangoAdminUrlPath }}
             pathType: Exact
 
     - host: {{ .Values.domain | quote }}
@@ -89,7 +89,7 @@ spec:
                 name: {{ .Release.Name }}-studio
                 port:
                   number: 8080
-            path: {{ .Values.studio.adminPath }}/
+            path: {{ .Values.studio.djangoAdminUrlPath }}/
             pathType: Prefix
 {{- end }}
 {{- end }}

--- a/serve/templates/ingress-platform.yaml
+++ b/serve/templates/ingress-platform.yaml
@@ -56,6 +56,42 @@ spec:
                 number: 8081
           pathType: ImplementationSpecific
   {{- end }}
+---
+{{if neq .Values.environment "local" }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: admin-ingress
+  annotations:
+    # POI: here we are allowing access to /admin/* only to 130.238.0.0/16
+    nginx.ingress.kubernetes.io/whitelist-source-range: 130.238.0.0/16
+  labels:
+    io.kompose.service: {{ .Release.Name }}-ingress
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: {{ .Values.domain | quote }}
+      http:
+        paths:
+          - backend:
+              service:
+                name: {{ .Release.Name }}-studio
+                port:
+                  number: 8080
+            path: {{ .Values.studio.adminPath }}
+            pathType: Exact
+
+    - host: {{ .Values.domain | quote }}
+      http:
+        paths:
+          - backend:
+              service:
+                name: {{ .Release.Name }}-studio
+                port:
+                  number: 8080
+            path: {{ .Values.studio.adminPath }}/
+            pathType: Prefix
+{{- end }}
 {{- end }}
 
 

--- a/serve/templates/ingress-platform.yaml
+++ b/serve/templates/ingress-platform.yaml
@@ -78,7 +78,7 @@ spec:
                 name: {{ .Release.Name }}-studio
                 port:
                   number: 8080
-            path: {{ .Values.studio.djangoAdminUrlPath }}
+            path: /{{ .Values.studio.djangoAdminUrlPath }}
             pathType: Exact
 
     - host: {{ .Values.domain | quote }}
@@ -89,7 +89,7 @@ spec:
                 name: {{ .Release.Name }}-studio
                 port:
                   number: 8080
-            path: {{ .Values.studio.djangoAdminUrlPath }}/
+            path: /{{ .Values.studio.djangoAdminUrlPath }}/
             pathType: Prefix
 {{- end }}
 {{- end }}

--- a/serve/templates/studio-deployment.yaml
+++ b/serve/templates/studio-deployment.yaml
@@ -110,11 +110,16 @@ spec:
             secretKeyRef:
               name: {{ include "stackn.redis.secretName" . }}
               key: {{ include "stackn.redis.secretPasswordKey" . }}
+        {{ if .Values.studio.githubApiToken }}
         - name: GITHUB_API_TOKEN
           valueFrom:
             secretKeyRef:
               name: {{ include "stackn.secretName" . }}
               key: github-api-token
+        {{ else }}
+        - name: GITHUB_API_TOKEN
+          value: ""
+        {{ end }}
         - name: RABBITMQ_DEFAULT_PASS
           valueFrom:
             secretKeyRef:

--- a/serve/templates/studio-deployment.yaml
+++ b/serve/templates/studio-deployment.yaml
@@ -90,7 +90,7 @@ spec:
               name: {{ include "stackn.secretName" . }}
               key: studio-superuser-password
         - name: DJANGO_ADMIN_URL_PATH
-          value: {{ .Values.studio.adminPath }}
+          value: {{ .Values.studio.djangoAdminUrlPath }}
         - name: EVENT_USER_EMAIL
           value: {{ include "stackn.studio.eventuser.email" . }}
         - name: EVENT_USER_PASSWORD

--- a/serve/templates/studio-deployment.yaml
+++ b/serve/templates/studio-deployment.yaml
@@ -89,6 +89,8 @@ spec:
             secretKeyRef:
               name: {{ include "stackn.secretName" . }}
               key: studio-superuser-password
+        - name: DJANGO_ADMIN_URL_PATH
+          value: {{ .Values.studio.adminPath }}
         - name: EVENT_USER_EMAIL
           value: {{ include "stackn.studio.eventuser.email" . }}
         - name: EVENT_USER_PASSWORD

--- a/serve/templates/studio-settings-configmap.yaml
+++ b/serve/templates/studio-settings-configmap.yaml
@@ -40,6 +40,7 @@ data:
 
     # SECURITY WARNING: keep the secret key used in production secret!
     SECRET_KEY = os.environ["DJANGO_SECRET"]
+    DJANGO_ADMIN_URL_PATH = os.environ["DJANGO_ADMIN_URL_PATH"]
 
     # SECURITY WARNING: don't run with debug turned on in production
     {{ if .Values.studio.debug }}

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -118,7 +118,7 @@ studio:
   superUser: admin
   superuserPassword: ""
   superuserEmail: admin@serve.scilifelab.se
-  djangoAdminUrlPath: "/admin"
+  djangoAdminUrlPath: "admin"
   eventUser: ""
   eventuserPassword: ""
   eventuserEmail: event_user@serve.scilifelab.se

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -118,7 +118,7 @@ studio:
   superUser: admin
   superuserPassword: ""
   superuserEmail: admin@serve.scilifelab.se
-  adminPath: "/admin"
+  djangoAdminUrlPath: "/admin"
   eventUser: ""
   eventuserPassword: ""
   eventuserEmail: event_user@serve.scilifelab.se

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -118,6 +118,7 @@ studio:
   superUser: admin
   superuserPassword: ""
   superuserEmail: admin@serve.scilifelab.se
+  adminPath: "/admin"
   eventUser: ""
   eventuserPassword: ""
   eventuserEmail: event_user@serve.scilifelab.se


### PR DESCRIPTION
This pull request introduces several changes to the configuration and deployment templates for the studio application, focusing on adding support for a customizable Django admin URL path and handling GitHub API tokens more flexibly. The most important changes include updates to the `serve/templates` and `serve/values.yaml` files.

### Configuration Enhancements:

* [`serve/values.yaml`](diffhunk://#diff-1a1b8fb31cc8d8dfacce59fa9448b28b3caf8c6f54e9619f992659a5784bc5d5R121): Added a new configuration value `djangoAdminUrlPath` to allow customization of the Django admin URL path.

### Deployment Template Updates:

* [`serve/templates/studio-deployment.yaml`](diffhunk://#diff-aef888ff5ea5fd1f0055c1273fe7fd3f4714a7c24069fae3e99e30091c7f17dbR92-R93): Added an environment variable `DJANGO_ADMIN_URL_PATH` to the deployment spec and updated the handling of `GITHUB_API_TOKEN` to support conditional inclusion based on the presence of the token. [[1]](diffhunk://#diff-aef888ff5ea5fd1f0055c1273fe7fd3f4714a7c24069fae3e99e30091c7f17dbR92-R93) [[2]](diffhunk://#diff-aef888ff5ea5fd1f0055c1273fe7fd3f4714a7c24069fae3e99e30091c7f17dbR115-R124)

### Ingress Configuration:

* [`serve/templates/ingress-platform.yaml`](diffhunk://#diff-5736cb0c048364ad7e0e0cb163956253f007b610d22609fe6070de102aa9b102R59-R94): Added a new ingress rule to restrict access to the Django admin URL path to a specific IP range, ensuring better security.

### Secret Management:

* [`serve/templates/basic-secrets.yaml`](diffhunk://#diff-fa2af166e048bfec8ecfd7d77937dbd9b9338501c2341948ef0ecadb65dad95eR20-R22): Added conditional logic to include `github-api-token` only if it is defined in the values file.

### Settings Configuration:

* [`serve/templates/studio-settings-configmap.yaml`](diffhunk://#diff-a4149687da9e5d0f2347464414eb1258d0a87f957394156250ee4803d98df7b2R43): Added `DJANGO_ADMIN_URL_PATH` to the Django settings to utilize the new customizable admin URL path.