### PR TITLE
Fix missing environment variables

### DIFF
--- a/serve/templates/celery-beat-deployment.yaml
+++ b/serve/templates/celery-beat-deployment.yaml
@@ -95,6 +95,8 @@ spec:
             secretKeyRef:
               name: {{ include "stackn.secretName" . }}
               key: django-secret-key
+        - name: DJANGO_ADMIN_URL_PATH
+          value: {{ .Values.studio.djangoAdminUrlPath }}
         {{ if .Values.studio.emailService.enabled }}
         - name: EMAIL_HOST_USER
           valueFrom:

--- a/serve/templates/celery-flower-deployment.yaml
+++ b/serve/templates/celery-flower-deployment.yaml
@@ -84,6 +84,8 @@ spec:
               name: {{ include "stackn.secretName" . }}
               key: email-host-password
         {{- end }}
+        - name: DJANGO_ADMIN_URL_PATH
+          value: {{ .Values.studio.djangoAdminUrlPath }}
         image: {{ .Values.studio.image.repository }}
         imagePullPolicy: {{ .Values.studio.image.pullPolicy }}
         name: {{ .Release.Name }}-celery-worker

--- a/serve/templates/celery-worker-deployment.yaml
+++ b/serve/templates/celery-worker-deployment.yaml
@@ -108,6 +108,8 @@ spec:
               name: {{ include "stackn.secretName" . }}
               key: email-host-password
         {{- end }}
+        - name: DJANGO_ADMIN_URL_PATH
+          value: {{ .Values.studio.djangoAdminUrlPath }}
         image: {{ .Values.studio.image.repository }}
         imagePullPolicy: {{ .Values.studio.image.pullPolicy }}
         name: {{ .Release.Name }}-celery-worker

--- a/serve/templates/studio-settings-configmap.yaml
+++ b/serve/templates/studio-settings-configmap.yaml
@@ -40,7 +40,7 @@ data:
 
     # SECURITY WARNING: keep the secret key used in production secret!
     SECRET_KEY = os.environ["DJANGO_SECRET"]
-    DJANGO_ADMIN_URL_PATH = os.environ["DJANGO_ADMIN_URL_PATH"]
+    DJANGO_ADMIN_URL_PATH = os.getenv("DJANGO_ADMIN_URL_PATH", "admin")
 
     # SECURITY WARNING: don't run with debug turned on in production
     {{ if .Values.studio.debug }}


### PR DESCRIPTION
Fixing issue based on this https://stackoverflow.com/questions/40915735/start-celery-worker-throws-no-attribute-worker-state-db