### PR TITLE
ss-1388 Replace matrix in Github workflow

### DIFF
--- a/.github/workflows/bump_chart_version_in_serve_repo.yaml
+++ b/.github/workflows/bump_chart_version_in_serve_repo.yaml
@@ -8,7 +8,26 @@ on:
       - "apps/**/Chart.yaml"
 
 jobs:
+  detect-changed-app:
+    runs-on: ubuntu-latest
+    outputs:
+      changed_app: ${{ steps.find-app.outputs.changed_app }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          
+      - name: Find changed Chart.yaml
+        id: find-app
+        run: |
+          CHANGED_FILES=$(git diff --name-only HEAD^ HEAD | grep "apps/.*Chart.yaml" || echo "")
+          APP_NAME=$(echo "$CHANGED_FILES" | head -n 1 | sed -E 's|apps/([^/]+)/Chart.yaml|\1|')
+          echo "changed_app=$APP_NAME" >> $GITHUB_OUTPUT
+          echo "Found changed app: $APP_NAME"
+
   update-json:
+    needs: detect-changed-app
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -30,6 +49,8 @@ jobs:
           - name: tissuumaps
             helm_name: tissuumaps
   
+    if: ${{ matrix.app.name == needs.detect-changed-app.outputs.changed_app }}
+
     steps:
       - name: Check out serve-charts repository
         uses: actions/checkout@v4

--- a/.github/workflows/bump_chart_version_in_serve_repo.yaml
+++ b/.github/workflows/bump_chart_version_in_serve_repo.yaml
@@ -8,63 +8,55 @@ on:
       - "apps/**/Chart.yaml"
 
 jobs:
-  detect-changed-app:
+  update-json:
     runs-on: ubuntu-latest
-    outputs:
-      changed_app: ${{ steps.find-app.outputs.changed_app }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          token: ${{ secrets.TW_PAT }}
           
-      - name: Find changed Chart.yaml
+      - name: Find changed Chart.yaml and set variables
         id: find-app
         run: |
+          # Find the changed Chart.yaml file
           CHANGED_FILES=$(git diff --name-only HEAD^ HEAD | grep "apps/.*Chart.yaml" || echo "")
+          
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No Chart.yaml files changed. Exiting."
+            exit 0
+          fi
+          
+          # Extract app name from path
           APP_NAME=$(echo "$CHANGED_FILES" | head -n 1 | sed -E 's|apps/([^/]+)/Chart.yaml|\1|')
-          echo "changed_app=$APP_NAME" >> $GITHUB_OUTPUT
           echo "Found changed app: $APP_NAME"
-
-  update-json:
-    needs: detect-changed-app
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        app:
-          - name: custom-app
-            helm_name: custom-app
-          - name: dash
-            helm_name: dash-app
-          - name: filemanager
-            helm_name: filemanager
-          - name: jupyter-lab
-            helm_name: lab
-          - name: rstudio
-            helm_name: rstudio
-          - name: shiny
-            helm_name: shinyapp
-          - name: shinyproxy
-            helm_name: shinyproxy
-          - name: tissuumaps
-            helm_name: tissuumaps
-  
-    if: ${{ matrix.app.name == needs.detect-changed-app.outputs.changed_app }}
-
-    steps:
-      - name: Check out serve-charts repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.TW_PAT }}
-
-      - name: Set up environment variables
-        run: |
-          HELM_CHART=${{ matrix.app.helm_name }}
-          CHART_PATH=apps/${{ matrix.app.name }}/Chart.yaml
-          echo "HELM_CHART=$HELM_CHART" >> "$GITHUB_ENV"
+          
+          # Map the app name to helm name
+          case "$APP_NAME" in
+            "custom-app") HELM_NAME="custom-app" ;;
+            "dash") HELM_NAME="dash-app" ;;
+            "filemanager") HELM_NAME="filemanager" ;;
+            "jupyter-lab") HELM_NAME="lab" ;;
+            "rstudio") HELM_NAME="rstudio" ;;
+            "shiny") HELM_NAME="shinyapp" ;;
+            "shinyproxy") HELM_NAME="shinyproxy" ;;
+            "tissuumaps") HELM_NAME="tissuumaps" ;;
+            *) 
+              echo "Unknown app: $APP_NAME. Exiting."
+              exit 1
+              ;;
+          esac
+          
+          # Get the chart version
+          CHART_PATH="apps/$APP_NAME/Chart.yaml"
           NEW_CHART_VERSION=$(yq e '.version' $CHART_PATH)
-          echo "NEW_CHART_VERSION=$NEW_CHART_VERSION" >> $GITHUB_ENV
-          echo "JSON_FILE_PATH=fixtures/apps_fixtures.json" >> $GITHUB_ENV
+          
+          # Export variables for later steps
+          echo "HELM_CHART=$HELM_NAME" >> "$GITHUB_ENV"
+          echo "APP_NAME=$APP_NAME" >> "$GITHUB_ENV"
+          echo "NEW_CHART_VERSION=$NEW_CHART_VERSION" >> "$GITHUB_ENV"
+          echo "JSON_FILE_PATH=fixtures/apps_fixtures.json" >> "$GITHUB_ENV"
 
       - name: Set up the SSH key
         run: |

--- a/.github/workflows/bump_chart_version_in_serve_repo.yaml
+++ b/.github/workflows/bump_chart_version_in_serve_repo.yaml
@@ -87,12 +87,27 @@ jobs:
       - name: Update JSON file in the Serve repository
         run: |
           cd serve
+          git checkout develop
           git checkout -b update/${{ env.HELM_CHART }}-${{ env.NEW_CHART_VERSION }}
+
+          # Debug 1
+          grep -A 1 "${{ env.HELM_CHART }}" $JSON_FILE_PATH || echo "Pattern not found"
+
           jq -M --arg new_chart_version "$NEW_CHART_VERSION" 'map(if .fields.chart | contains("${{ env.HELM_CHART }}:") then .fields.chart |= sub(":[^:]+$"; ":" + $new_chart_version) else . end)' $JSON_FILE_PATH > tmp.json
+
+          # Debug 2
+          echo "Changes to be applied:"
+          diff -u $JSON_FILE_PATH tmp.json || echo "No differences in diff" 
+
           mv tmp.json $JSON_FILE_PATH
           git add $JSON_FILE_PATH
-          git diff --quiet || git commit -S -m "Update chart version in ${{ env.HELM_CHART }} to ${{ env.NEW_CHART_VERSION }}"
-          git push -u origin update/${{ env.HELM_CHART }}-${{ env.NEW_CHART_VERSION }}
+          if git diff --staged --quiet; then
+            echo "No changes to commit. The chart version might already be up-to-date."
+            exit 1
+          else
+            git commit -S -m "Update chart version in ${{ env.HELM_CHART }} to ${{ env.NEW_CHART_VERSION }}"
+            git push -u origin update/${{ env.HELM_CHART }}-${{ env.NEW_CHART_VERSION }}
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.TW_PAT }}
 

--- a/.github/workflows/bump_chart_version_in_serve_repo.yaml
+++ b/.github/workflows/bump_chart_version_in_serve_repo.yaml
@@ -102,7 +102,6 @@ jobs:
 
       - name: Create a pull request in the Serve repository
         run: |
-          gh auth login --with-token <<< "${{ secrets.TW_PAT }}"
           gh pr create \
             --repo ScilifelabDataCentre/serve \
             --head update/${{ env.HELM_CHART }}-${{ env.NEW_CHART_VERSION }} \

--- a/.github/workflows/bump_chart_version_in_serve_repo.yaml
+++ b/.github/workflows/bump_chart_version_in_serve_repo.yaml
@@ -1,7 +1,9 @@
 name: New Helm chart version
 
 on:
-  pull_request:
+  push:
+    branches:
+      - ss-1388-bug-fix
     paths:
       - "apps/**/Chart.yaml"
 

--- a/.github/workflows/bump_chart_version_in_serve_repo.yaml
+++ b/.github/workflows/bump_chart_version_in_serve_repo.yaml
@@ -69,6 +69,11 @@ jobs:
         run: |
           git config --global user.name "$GITHUB_ACTOR"
           git config --global user.email "teamwhale@scilifelab.se"
+          # Check if the directory already exists
+          if [ -d "serve" ]; then
+            echo "Directory 'serve' already exists, removing it first..."
+            rm -rf serve
+          fi
           git clone git@github.com:ScilifelabDataCentre/serve.git
 
       - name: Import GPG key and configure commit signing

--- a/.github/workflows/bump_chart_version_in_serve_repo.yaml
+++ b/.github/workflows/bump_chart_version_in_serve_repo.yaml
@@ -92,23 +92,23 @@ jobs:
           git add $JSON_FILE_PATH
           git diff --quiet || git commit -S -m "Update chart version in ${{ env.HELM_CHART }} to ${{ env.NEW_CHART_VERSION }}"
 
-      - name: Push changes to the Serve repository
+      - name: Push changes to a new branch in the Serve repository
         run: |
           cd serve
-          git push origin HEAD
+          git checkout -b update/${{ env.HELM_CHART }}-${{ env.NEW_CHART_VERSION }}
+          git push -u origin update/${{ env.HELM_CHART }}-${{ env.NEW_CHART_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.TW_PAT }}
 
       - name: Create a pull request in the Serve repository
-        uses: peter-evans/create-pull-request@v3
-        with:
-          token: ${{ secrets.TW_PAT }}
-          commit-message: "Update apps_fixtures.json"
-          committer: ${{ github.actor }} <teamwhale@scilifelab.se>
-          author: ${{ github.actor }} <teamwhale@scilifelab.se>
-          branch: update/${{ env.HELM_CHART }}-${{ env.NEW_CHART_VERSION }}
-          title: '[Automated PR] Update chart version in ${{ env.HELM_CHART }} to ${{ env.NEW_CHART_VERSION }}'
-          body: |
-            This PR updates the `chart` field in `app_fixtures.json` to use the new version: `${{ env.NEW_CHART_VERSION }}`.
-            Please review and merge if everything looks good.
-          path: serve
+        run: |
+          gh auth login --with-token <<< "${{ secrets.TW_PAT }}"
+          gh pr create \
+            --repo ScilifelabDataCentre/serve \
+            --head update/${{ env.HELM_CHART }}-${{ env.NEW_CHART_VERSION }} \
+            --base develop \
+            --title "[Automated PR] Update chart version in ${{ env.HELM_CHART }} to ${{ env.NEW_CHART_VERSION }}" \
+            --body "This PR updates the \`chart\` field in \`app_fixtures.json\` to use the new version: \`${{ env.NEW_CHART_VERSION }}\`.
+          Please review and merge if everything looks good."
+        env:
+          GITHUB_TOKEN: ${{ secrets.TW_PAT }}

--- a/.github/workflows/bump_chart_version_in_serve_repo.yaml
+++ b/.github/workflows/bump_chart_version_in_serve_repo.yaml
@@ -88,11 +88,11 @@ jobs:
         run: |
           cd serve
           git checkout -b update/${{ env.HELM_CHART }}-${{ env.NEW_CHART_VERSION }}
-          git push -u origin update/${{ env.HELM_CHART }}-${{ env.NEW_CHART_VERSION }}
           jq -M --arg new_chart_version "$NEW_CHART_VERSION" 'map(if .fields.chart | contains("${{ env.HELM_CHART }}:") then .fields.chart |= sub(":[^:]+$"; ":" + $new_chart_version) else . end)' $JSON_FILE_PATH > tmp.json
           mv tmp.json $JSON_FILE_PATH
           git add $JSON_FILE_PATH
           git diff --quiet || git commit -S -m "Update chart version in ${{ env.HELM_CHART }} to ${{ env.NEW_CHART_VERSION }}"
+          git push -u origin update/${{ env.HELM_CHART }}-${{ env.NEW_CHART_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.TW_PAT }}
 

--- a/.github/workflows/bump_chart_version_in_serve_repo.yaml
+++ b/.github/workflows/bump_chart_version_in_serve_repo.yaml
@@ -1,9 +1,7 @@
 name: New Helm chart version
 
 on:
-  push:
-    branches:
-      - ss-1388-bug-fix
+  pull_request:
     paths:
       - "apps/**/Chart.yaml"
 
@@ -90,12 +88,12 @@ jobs:
           git checkout develop
           git checkout -b update/${{ env.HELM_CHART }}-${{ env.NEW_CHART_VERSION }}
 
-          # Debug 1
+          # Check if pattern exists in the JSON file
           grep -A 1 "${{ env.HELM_CHART }}" $JSON_FILE_PATH || echo "Pattern not found"
 
           jq -M --arg new_chart_version "$NEW_CHART_VERSION" 'map(if .fields.chart | contains("${{ env.HELM_CHART }}:") then .fields.chart |= sub(":[^:]+$"; ":" + $new_chart_version) else . end)' $JSON_FILE_PATH > tmp.json
 
-          # Debug 2
+          # Check if the jq command was successful
           echo "Changes to be applied:"
           diff -u $JSON_FILE_PATH tmp.json || echo "No differences in diff" 
 

--- a/.github/workflows/bump_chart_version_in_serve_repo.yaml
+++ b/.github/workflows/bump_chart_version_in_serve_repo.yaml
@@ -87,16 +87,12 @@ jobs:
       - name: Update JSON file in the Serve repository
         run: |
           cd serve
+          git checkout -b update/${{ env.HELM_CHART }}-${{ env.NEW_CHART_VERSION }}
+          git push -u origin update/${{ env.HELM_CHART }}-${{ env.NEW_CHART_VERSION }}
           jq -M --arg new_chart_version "$NEW_CHART_VERSION" 'map(if .fields.chart | contains("${{ env.HELM_CHART }}:") then .fields.chart |= sub(":[^:]+$"; ":" + $new_chart_version) else . end)' $JSON_FILE_PATH > tmp.json
           mv tmp.json $JSON_FILE_PATH
           git add $JSON_FILE_PATH
           git diff --quiet || git commit -S -m "Update chart version in ${{ env.HELM_CHART }} to ${{ env.NEW_CHART_VERSION }}"
-
-      - name: Push changes to a new branch in the Serve repository
-        run: |
-          cd serve
-          git checkout -b update/${{ env.HELM_CHART }}-${{ env.NEW_CHART_VERSION }}
-          git push -u origin update/${{ env.HELM_CHART }}-${{ env.NEW_CHART_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.TW_PAT }}
 

--- a/apps/custom-app/Chart.yaml
+++ b/apps/custom-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart for a standard serve app
 name: custom-app
-version: 1.1.4
+version: 1.1.6
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se

--- a/apps/custom-app/Chart.yaml
+++ b/apps/custom-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart for a standard serve app
 name: custom-app
-version: 1.1.6
+version: 1.1.5
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se

--- a/apps/custom-app/Chart.yaml
+++ b/apps/custom-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart for a standard serve app
 name: custom-app
-version: 1.1.6
+version: 1.1.3
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se

--- a/apps/custom-app/Chart.yaml
+++ b/apps/custom-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart for a standard serve app
 name: custom-app
-version: 1.1.5
+version: 1.1.6
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se

--- a/apps/custom-app/Chart.yaml
+++ b/apps/custom-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart for a standard serve app
 name: custom-app
-version: 1.1.6
+version: 1.1.7
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se

--- a/apps/custom-app/Chart.yaml
+++ b/apps/custom-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart for a standard serve app
 name: custom-app
-version: 1.1.3
+version: 1.1.4
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se

--- a/apps/custom-app/Chart.yaml
+++ b/apps/custom-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart for a standard serve app
 name: custom-app
-version: 1.1.7
+version: 1.1.6
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se


### PR DESCRIPTION
This PR replaces the matrix structure in the Helm chart version bump workflow but keeps a single file for all of the Serve apps.