### PR TITLE
Added settings for the new email backend

### DIFF
--- a/serve/templates/basic-secrets.yaml
+++ b/serve/templates/basic-secrets.yaml
@@ -13,9 +13,17 @@ data:
   rabbit-password:  {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "rabbit-password" "providedValues" (list "rabbit.password") "context" $) }}
   django-secret-key:  {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "django-secret-key" "providedValues" (list "studio.djangoSecret") "length" 50 "strong" true "context" $) }}
   {{ if .Values.studio.emailService.enabled }}
-  email-host-user: {{ .Values.studio.emailService.hostUser | b64enc }}
-  email-host-password: {{ .Values.studio.emailService.hostPassword | b64enc }}
-  #email-api-key: {{ .Values.studio.emailService.apiKey | b64enc }}
+  email-google-service-account-type: {{ .Values.studio.emailService.googleServiceAccount.type }}
+  email-google-service-account-project_id: {{ .Values.studio.emailService.googleServiceAccount.project_id }}
+  email-google-service-account-private_key_id: {{ .Values.studio.emailService.googleServiceAccount.private_key_id }}
+  email-google-service-account-private_key: {{ .Values.studio.emailService.googleServiceAccount.private_key | b64enc }}
+  email-google-service-account-client_email: {{ .Values.studio.emailService.googleServiceAccount.client_email }}
+  email-google-service-account-client_id: {{ .Values.studio.emailService.googleServiceAccount.client_id }}
+  email-google-service-account-auth_uri: {{ .Values.studio.emailService.googleServiceAccount.auth_uri }}
+  email-google-service-account-token_uri: {{ .Values.studio.emailService.googleServiceAccount.token_uri }}
+  email-google-service-account-auth_provider_x509_cert_url: {{ .Values.studio.emailService.googleServiceAccount.auth_provider_x509_cert_url }}
+  email-google-service-account-client_x509_cert_url: {{ .Values.studio.emailService.googleServiceAccount.client_x509_cert_url }}
+  email-google-service-account-universe_domain: {{ .Values.studio.emailService.googleServiceAccount.universe_domain }}
   {{ end }}
   {{ if .Values.studio.githubApiToken }}
   github-api-token: {{ .Values.studio.githubApiToken | b64enc }}

--- a/serve/templates/basic-secrets.yaml
+++ b/serve/templates/basic-secrets.yaml
@@ -13,17 +13,17 @@ data:
   rabbit-password:  {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "rabbit-password" "providedValues" (list "rabbit.password") "context" $) }}
   django-secret-key:  {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "django-secret-key" "providedValues" (list "studio.djangoSecret") "length" 50 "strong" true "context" $) }}
   {{ if .Values.studio.emailService.enabled }}
-  email-google-service-account-type: {{ .Values.studio.emailService.googleServiceAccount.type }}
-  email-google-service-account-project_id: {{ .Values.studio.emailService.googleServiceAccount.project_id }}
-  email-google-service-account-private_key_id: {{ .Values.studio.emailService.googleServiceAccount.private_key_id }}
-  email-google-service-account-private_key: {{ .Values.studio.emailService.googleServiceAccount.private_key | b64enc }}
-  email-google-service-account-client_email: {{ .Values.studio.emailService.googleServiceAccount.client_email }}
-  email-google-service-account-client_id: {{ .Values.studio.emailService.googleServiceAccount.client_id }}
-  email-google-service-account-auth_uri: {{ .Values.studio.emailService.googleServiceAccount.auth_uri }}
-  email-google-service-account-token_uri: {{ .Values.studio.emailService.googleServiceAccount.token_uri }}
-  email-google-service-account-auth_provider_x509_cert_url: {{ .Values.studio.emailService.googleServiceAccount.auth_provider_x509_cert_url }}
-  email-google-service-account-client_x509_cert_url: {{ .Values.studio.emailService.googleServiceAccount.client_x509_cert_url }}
-  email-google-service-account-universe_domain: {{ .Values.studio.emailService.googleServiceAccount.universe_domain }}
+  email-google-service-account-type: {{ .Values.studio.emailService.googleServiceAccount.type | b64enc }}
+  email-google-service-account-project-id: {{ .Values.studio.emailService.googleServiceAccount.project_id | b64enc }}
+  email-google-service-account-private-key-id: {{ .Values.studio.emailService.googleServiceAccount.private_key_id | b64enc }}
+  email-google-service-account-private-key: {{ .Values.studio.emailService.googleServiceAccount.private_key | b64enc }}
+  email-google-service-account-client-email: {{ .Values.studio.emailService.googleServiceAccount.client_email | b64enc }}
+  email-google-service-account-client-id: {{ .Values.studio.emailService.googleServiceAccount.client_id | b64enc }}
+  email-google-service-account-auth-uri: {{ .Values.studio.emailService.googleServiceAccount.auth_uri | b64enc }}
+  email-google-service-account-token-uri: {{ .Values.studio.emailService.googleServiceAccount.token_uri | b64enc }}
+  email-google-service-account-auth-provider-x509-cert-url: {{ .Values.studio.emailService.googleServiceAccount.auth_provider_x509_cert_url | b64enc }}
+  email-google-service-account-client-x509-cert-url: {{ .Values.studio.emailService.googleServiceAccount.client_x509_cert_url | b64enc }}
+  email-google-service-account-universe-domain: {{ .Values.studio.emailService.googleServiceAccount.universe_domain | b64enc }}
   {{ end }}
   {{ if .Values.studio.githubApiToken }}
   github-api-token: {{ .Values.studio.githubApiToken | b64enc }}

--- a/serve/templates/celery-beat-deployment.yaml
+++ b/serve/templates/celery-beat-deployment.yaml
@@ -98,16 +98,61 @@ spec:
         - name: DJANGO_ADMIN_URL_PATH
           value: {{ .Values.studio.djangoAdminUrlPath }}
         {{ if .Values.studio.emailService.enabled }}
-        - name: EMAIL_HOST_USER
+        - name: GOOGLE_SERVICE_ACCOUNT_TYPE
           valueFrom:
             secretKeyRef:
               name: {{ include "stackn.secretName" . }}
-              key: email-host-user
-        - name: EMAIL_HOST_PASSWORD
+              key: email-google-service-account-type
+        - name: GOOGLE_SERVICE_ACCOUNT_PROJECT_ID
           valueFrom:
             secretKeyRef:
               name: {{ include "stackn.secretName" . }}
-              key: email-host-password
+              key: email-google-service-account-project-id
+        - name: GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-private-key-id
+        - name: GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-private-key
+        - name: GOOGLE_SERVICE_ACCOUNT_CLIENT_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-client-email
+        - name: GOOGLE_SERVICE_ACCOUNT_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-client-id
+        - name: GOOGLE_SERVICE_ACCOUNT_AUTH_URI
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-auth-uri
+        - name: GOOGLE_SERVICE_ACCOUNT_TOKEN_URI
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-token-uri
+        - name: GOOGLE_SERVICE_ACCOUNT_AUTH_PROVIDER_X509_CERT_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-auth-provider-x509-cert-url
+        - name: GOOGLE_SERVICE_ACCOUNT_CLIENT_X509_CERT_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-client-x509-cert-url
+        - name: GOOGLE_SERVICE_ACCOUNT_UNIVERSE_DOMAIN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-universe-domain
         {{- end }}
         image: {{ .Values.studio.image.repository }}
         imagePullPolicy: {{ .Values.studio.image.pullPolicy }}

--- a/serve/templates/celery-flower-deployment.yaml
+++ b/serve/templates/celery-flower-deployment.yaml
@@ -73,16 +73,61 @@ spec:
               name: {{ include "stackn.secretName" . }}
               key: django-secret-key
         {{ if .Values.studio.emailService.enabled }}
-        - name: EMAIL_HOST_USER
+        - name: GOOGLE_SERVICE_ACCOUNT_TYPE
           valueFrom:
             secretKeyRef:
               name: {{ include "stackn.secretName" . }}
-              key: email-host-user
-        - name: EMAIL_HOST_PASSWORD
+              key: email-google-service-account-type
+        - name: GOOGLE_SERVICE_ACCOUNT_PROJECT_ID
           valueFrom:
             secretKeyRef:
               name: {{ include "stackn.secretName" . }}
-              key: email-host-password
+              key: email-google-service-account-project-id
+        - name: GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-private-key-id
+        - name: GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-private-key
+        - name: GOOGLE_SERVICE_ACCOUNT_CLIENT_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-client-email
+        - name: GOOGLE_SERVICE_ACCOUNT_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-client-id
+        - name: GOOGLE_SERVICE_ACCOUNT_AUTH_URI
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-auth-uri
+        - name: GOOGLE_SERVICE_ACCOUNT_TOKEN_URI
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-token-uri
+        - name: GOOGLE_SERVICE_ACCOUNT_AUTH_PROVIDER_X509_CERT_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-auth-provider-x509-cert-url
+        - name: GOOGLE_SERVICE_ACCOUNT_CLIENT_X509_CERT_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-client-x509-cert-url
+        - name: GOOGLE_SERVICE_ACCOUNT_UNIVERSE_DOMAIN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-universe-domain
         {{- end }}
         - name: DJANGO_ADMIN_URL_PATH
           value: {{ .Values.studio.djangoAdminUrlPath }}

--- a/serve/templates/celery-worker-deployment.yaml
+++ b/serve/templates/celery-worker-deployment.yaml
@@ -97,16 +97,61 @@ spec:
               name: {{ include "stackn.secretName" . }}
               key: django-secret-key
         {{ if .Values.studio.emailService.enabled }}
-        - name: EMAIL_HOST_USER
+        - name: GOOGLE_SERVICE_ACCOUNT_TYPE
           valueFrom:
             secretKeyRef:
               name: {{ include "stackn.secretName" . }}
-              key: email-host-user
-        - name: EMAIL_HOST_PASSWORD
+              key: email-google-service-account-type
+        - name: GOOGLE_SERVICE_ACCOUNT_PROJECT_ID
           valueFrom:
             secretKeyRef:
               name: {{ include "stackn.secretName" . }}
-              key: email-host-password
+              key: email-google-service-account-project-id
+        - name: GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-private-key-id
+        - name: GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-private-key
+        - name: GOOGLE_SERVICE_ACCOUNT_CLIENT_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-client-email
+        - name: GOOGLE_SERVICE_ACCOUNT_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-client-id
+        - name: GOOGLE_SERVICE_ACCOUNT_AUTH_URI
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-auth-uri
+        - name: GOOGLE_SERVICE_ACCOUNT_TOKEN_URI
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-token-uri
+        - name: GOOGLE_SERVICE_ACCOUNT_AUTH_PROVIDER_X509_CERT_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-auth-provider-x509-cert-url
+        - name: GOOGLE_SERVICE_ACCOUNT_CLIENT_X509_CERT_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-client-x509-cert-url
+        - name: GOOGLE_SERVICE_ACCOUNT_UNIVERSE_DOMAIN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-universe-domain
         {{- end }}
         - name: DJANGO_ADMIN_URL_PATH
           value: {{ .Values.studio.djangoAdminUrlPath }}

--- a/serve/templates/studio-deployment.yaml
+++ b/serve/templates/studio-deployment.yaml
@@ -137,16 +137,61 @@ spec:
               name: {{ include "stackn.secretName" . }}
               key: django-secret-key
         {{ if .Values.studio.emailService.enabled }}
-        - name: EMAIL_HOST_USER
+        - name: GOOGLE_SERVICE_ACCOUNT_TYPE
           valueFrom:
             secretKeyRef:
               name: {{ include "stackn.secretName" . }}
-              key: email-host-user
-        - name: EMAIL_HOST_PASSWORD
+              key: email-google-service-account-type
+        - name: GOOGLE_SERVICE_ACCOUNT_PROJECT_ID
           valueFrom:
             secretKeyRef:
               name: {{ include "stackn.secretName" . }}
-              key: email-host-password
+              key: email-google-service-account-project-id
+        - name: GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-private-key-id
+        - name: GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-private-key
+        - name: GOOGLE_SERVICE_ACCOUNT_CLIENT_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-client-email
+        - name: GOOGLE_SERVICE_ACCOUNT_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-client-id
+        - name: GOOGLE_SERVICE_ACCOUNT_AUTH_URI
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-auth-uri
+        - name: GOOGLE_SERVICE_ACCOUNT_TOKEN_URI
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-token-uri
+        - name: GOOGLE_SERVICE_ACCOUNT_AUTH_PROVIDER_X509_CERT_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-auth-provider-x509-cert-url
+        - name: GOOGLE_SERVICE_ACCOUNT_CLIENT_X509_CERT_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-client-x509-cert-url
+        - name: GOOGLE_SERVICE_ACCOUNT_UNIVERSE_DOMAIN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: email-google-service-account-universe-domain
         {{ end }}
         image: {{ .Values.studio.image.repository }}
         imagePullPolicy: {{ .Values.studio.image.pullPolicy }}

--- a/serve/templates/studio-settings-configmap.yaml
+++ b/serve/templates/studio-settings-configmap.yaml
@@ -18,6 +18,7 @@ data:
     import logging
     import os
     import sys
+    import json
     from pathlib import Path
 
     import colorlog
@@ -115,6 +116,7 @@ data:
         "api",
         "axes",  # django-axes for brute force login protection
         "django_password_validators",  # django-password-validators for password validation
+        "gmailapi_backend",
     ] + DJANGO_WIKI_APPS
 
     {{ if .Values.studio.custom_apps.enabled }}
@@ -405,29 +407,32 @@ data:
     {{ if .Values.studio.debug }}
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
     {{ else }}
-    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    EMAIL_BACKEND = "gmailapi_backend.service.GmailApiBackend"
     {{ end }}
     {{ if .Values.studio.emailService.enabled }}
-    EMAIL_HOST = {{ .Values.studio.emailService.host | quote}}
-    EMAIL_PORT = {{ .Values.studio.emailService.port }}
-    EMAIL_HOST_USER = os.environ["EMAIL_HOST_USER"]
-    EMAIL_HOST_PASSWORD = os.environ["EMAIL_HOST_PASSWORD"]
-    # EMAIL_DOMAIN_NAME = {{ .Values.studio.emailService.domainName | quote}}
-    # EMAIL_API_KEY = os.environ["EMAIL_API_KEY"]
-    # EMAIL_MAILGUN_API = {{ .Values.studio.emailService.apiEndpoint | quote}}
-    # EMAIL_NOTIFY_ON_ACCOUNT_REGISTER_LIST = [{{- range .Values.studio.emailService.notifyOnAccountRegisterList }}{{. | quote }},{{- end }}]
-    # DEFAULT_FROM_EMAIL = {{ .Values.studio.emailService.smtpEmailFrom | quote}}
+    EMAIL_FROM = 'noreply-serve@scilifelab.se'
+    GMAIL_USER = 'noreply-serve@scilifelab.se'
+    GMAIL_SCOPES = ['https://www.googleapis.com/auth/gmail.send']
+    GOOGLE_SERVICE_ACCOUNT = json.dumps(
+        {
+            "type": os.getenv('GOOGLE_SERVICE_ACCOUNT_TYPE'),
+            "project_id": os.getenv('GOOGLE_SERVICE_ACCOUNT_PROJECT_ID'),
+            "private_key_id": os.getenv('GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY_ID'),
+            "private_key": os.getenv('GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY').replace("\\n", "\n"),
+            "client_email": os.getenv('GOOGLE_SERVICE_ACCOUNT_CLIENT_EMAIL'),
+            "client_id": os.getenv('GOOGLE_SERVICE_ACCOUNT_CLIENT_ID'),
+            "auth_uri": os.getenv('GOOGLE_SERVICE_ACCOUNT_AUTH_URI'),
+            "token_uri": os.getenv('GOOGLE_SERVICE_ACCOUNT_TOKEN_URI'),
+            "auth_provider_x509_cert_url": os.getenv('GOOGLE_SERVICE_ACCOUNT_AUTH_PROVIDER_X509_CERT_URL'),
+            "client_x509_cert_url": os.getenv('GOOGLE_SERVICE_ACCOUNT_CLIENT_X509_CERT_URL'),
+            "universe_domain": os.getenv('GOOGLE_SERVICE_ACCOUNT_UNIVERSE_DOMAIN'),
+        }
+            )
     {{ else }}
     EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"
     EMAIL_FILE_PATH =  os.path.join(BASE_DIR, 'sent_emails')
     {{ end }}
-    {{ if .Values.studio.emailService.ssl }}
-    EMAIL_USE_TLS = False
-    EMAIL_USE_SSL = True
-    {{ else }}
-    EMAIL_USE_TLS = True
-    {{ end }}
-    EMAIL_TEMPLATE_PROTOCOL = "https"
+
 
     VERSION = {{ .Values.studio.version | quote  }}
 

--- a/serve/templates/studio-settings-configmap.yaml
+++ b/serve/templates/studio-settings-configmap.yaml
@@ -418,7 +418,7 @@ data:
             "type": os.getenv('GOOGLE_SERVICE_ACCOUNT_TYPE'),
             "project_id": os.getenv('GOOGLE_SERVICE_ACCOUNT_PROJECT_ID'),
             "private_key_id": os.getenv('GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY_ID'),
-            "private_key": os.getenv('GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY').replace("\\n", "\n"),
+            "private_key": os.getenv('GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY', '').replace("\\n", "\n"),
             "client_email": os.getenv('GOOGLE_SERVICE_ACCOUNT_CLIENT_EMAIL'),
             "client_id": os.getenv('GOOGLE_SERVICE_ACCOUNT_CLIENT_ID'),
             "auth_uri": os.getenv('GOOGLE_SERVICE_ACCOUNT_AUTH_URI'),

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -155,6 +155,18 @@ studio:
     apiKey: ''
     notifyOnAccountRegisterList:
       - ''
+    googleServiceAccount:
+      type: ''
+      project_id: ''
+      private_key_id: ''
+      private_key: ''
+      client_email: ''
+      client_id: ''
+      auth_uri: ''
+      token_uri: ''
+      auth_provider_x509_cert_url: ''
+      client_x509_cert_url: ''
+      universe_domain: ''
   disabledAppInstanceFields:
     enabled: false
     fields:

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -145,14 +145,6 @@ studio:
   djangoSecret: ''
   emailService:
     enabled: false
-    host: ''
-    port: 587
-    hostUser: ''
-    hostPassword: ''
-    smtpEmailFrom: ''
-    domainName: ''
-    apiEndpoint: ''
-    apiKey: ''
     notifyOnAccountRegisterList:
       - ''
     googleServiceAccount:


### PR DESCRIPTION
Created a pr against staging environment.

- Setting secrets for email sending using oauth
- Secrets will be taken from bitwarden
- https://github.com/innoveit/django-gmailapi-json-backend/tree/main is being used as email backend