### PR TITLE
SS-1076 add Docker Hub credentials to deployment and configuration files

### DIFF
--- a/serve/templates/basic-secrets.yaml
+++ b/serve/templates/basic-secrets.yaml
@@ -28,4 +28,7 @@ data:
   {{ if .Values.studio.githubApiToken }}
   github-api-token: {{ .Values.studio.githubApiToken | b64enc }}
   {{ end }}
+  {{ if .Values.studio.dockerhubToken }}
+  docker-hub-token: {{ .Values.studio.dockerhubToken | b64enc }}
+  {{ end }}
 {{- end -}}

--- a/serve/templates/studio-deployment.yaml
+++ b/serve/templates/studio-deployment.yaml
@@ -118,8 +118,26 @@ spec:
             secretKeyRef:
               name: {{ include "stackn.secretName" . }}
               key: github-api-token
+        - name: GITHUB_API_USERNAME
+          value: {{ .Values.studio.githubApiUsername | quote }}
         {{ else }}
         - name: GITHUB_API_TOKEN
+          value: ""
+        - name: GITHUB_API_USERNAME
+          value: ""
+        {{ end }}
+        {{ if not .Values.studio.dockerhubUsername }}
+        - name: DOCKER_HUB_USERNAME
+          value: {{ .Values.studio.dockerhubUsername | quote }}
+        - name: DOCKER_HUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "stackn.secretName" . }}
+              key: docker-hub-token
+        {{ else }}
+        - name: DOCKER_HUB_USERNAME
+          value: ""
+        - name: DOCKER_HUB_TOKEN
           value: ""
         {{ end }}
         - name: RABBITMQ_DEFAULT_PASS

--- a/serve/templates/studio-settings-configmap.yaml
+++ b/serve/templates/studio-settings-configmap.yaml
@@ -380,10 +380,13 @@ data:
     # Docker hub API
     DOCKER_HUB_REPO_SEARCH = 'https://hub.docker.com/v2/search/repositories'
     DOCKER_HUB_TAG_SEARCH = 'https://hub.docker.com/v2/repositories'
+    DOCKER_HUB_TOKEN = os.getenv("DOCKER_HUB_TOKEN")
+    DOCKER_HUB_USERNAME = os.getenv("DOCKER_HUB_USERNAME")
 
     # GHCR API
     GITHUB_API = 'https://api.github.com'
     GITHUB_API_TOKEN = os.getenv('GITHUB_API_TOKEN')
+    GITHUB_API_USERNAME = os.getenv('GITHUB_API_USERNAME')
 
     # Apps
     APPS_MODEL = "apps.Apps"

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -173,6 +173,9 @@ studio:
     maxSize: 4
     timeout: 10
   githubApiToken:
+  githubApiUsername:
+  dockerhubToken:
+  dockerhubUsername:
 
 #kubernetes config
 kubeconfig: ""


### PR DESCRIPTION
These credentials are necessary in order to check docker images architecture