### PR TITLE
minio-storage-visibility policy

### DIFF
--- a/serve/templates/network-policies.yaml
+++ b/serve/templates/network-policies.yaml
@@ -373,5 +373,28 @@ spec:
       web: studio-web
   policyTypes:
     - Egress
+---
+# this policy enables retrieving MLflow server storage information on credential page (SS-1380)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-from-studio-to-minio
+  namespace: {{ .Values.namespace | default "default" }}
+spec:
+  podSelector:
+    matchLabels:
+      app: stackn-studio
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/component: minio
+    ports:
+    - protocol: TCP
+      port: 80
+    - protocol: TCP
+      port: 9000
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This policy enables retrieving MLflow server storage information on credential page ([SS-1380](https://scilifelab.atlassian.net/browse/SS-1380))