### PR TITLE
SS 1531 Enable curl and shinyproxy mgmt access from studio pods to apps

### DIFF
--- a/apps/shinyproxy/templates/deployment.yaml
+++ b/apps/shinyproxy/templates/deployment.yaml
@@ -39,7 +39,10 @@ spec:
       - name: serve
         image: {{ .Values.appconfig.proxyimage }}
         ports:
-          - containerPort: {{ .Values.appconfig.proxyport }}
+          - name: access
+            containerPort: {{ .Values.appconfig.proxyport }}
+          - name: management
+            containerPort: 9091
         volumeMounts:
           - name: application-conf-{{ .Release.Name }}
             mountPath: /opt/shinyproxy/config

--- a/apps/shinyproxy/templates/service.yaml
+++ b/apps/shinyproxy/templates/service.yaml
@@ -7,8 +7,13 @@ metadata:
     run: {{ .Release.Name }}-shinyapp
 spec:
   ports:
-  - protocol: TCP
-    port: 80
-    targetPort: {{ .Values.appconfig.proxyport }}
+    - name: access
+      protocol: TCP
+      port: 80
+      targetPort: {{ .Values.appconfig.proxyport }}
+    - name: management
+      port: 9091
+      targetPort: management    # resolves to containerPort 9091
+      protocol: TCP
   selector:
     release: {{ $.Release.Name }}

--- a/serve/templates/network-policies.yaml
+++ b/serve/templates/network-policies.yaml
@@ -396,5 +396,33 @@ spec:
       port: 80
     - protocol: TCP
       port: 9000
+---
+# This policy allows studio pods such as the event listener to check status of shiny proxy apps (SS-1531)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-studio-to-shinyproxy
+  namespace: {{ .Values.namespace | default "default" }}
+spec:
+  podSelector:
+    matchLabels:
+      app: stackn-studio
+  policyTypes:
+  - Egress
+  egress:
+    to:
+      - podSelector:
+          matchExpressions:
+            - key: app
+              operator: In
+              values:
+                - shinyproxy-deployment
+          matchLabels:
+            app: shinyproxy-deployment
+    ports:
+    - protocol: TCP
+      port: 8080
+    - protocol: TCP
+      port: 9091
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Add egress to allow studio pods access to shiny proxy deployments. Configure port 9091 for shinyproxy management.