### PR TITLE
SS 1254 Add two new env vars for the event-listener

### DIFF
--- a/serve/templates/event-listener-deployment.yaml
+++ b/serve/templates/event-listener-deployment.yaml
@@ -57,6 +57,10 @@ spec:
         {{- else }}
           value: "false"
         {{- end }}
+        - name: TLS_SSL_VERIFICATION
+          value: {{ .Values.eventListener.tlsSSLVerification | default "1" | quote }}
+        - name: APP_PROBE_STATUSES
+          value: {{ .Values.eventListener.appProbeStatuses | default "Running,Deleted" | quote }}
         - name: USERNAME
           value: {{ include "stackn.studio.eventuser.email" . }}
         - name: PASSWORD

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -303,8 +303,10 @@ reloader:
     watchGlobally: false
 
 eventListener:
-  image: ghcr.io/scilifelabdatacentre/serve-event-listener/event-listener:v1.1.1
+  image: ghcr.io/scilifelabdatacentre/serve-event-listener/event-listener:v1.3.0
   debug: true
+  tlsSSLVerification: "1"            # "0" / "1" / "/path/to/ca.pem"
+  appProbeStatuses: "Running,Deleted"  # "" disables probing completely
   resources:
     requests:
       cpu: "100m"


### PR DESCRIPTION
Bump the version of the event-listener to v1.3.0 and add two new env vars:
- TLS_SSL_VERIFICATION
- APP_PROBE_STATUSES