### PR TITLE
Renovate - Update config to detect latest Serve dev image tags

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,21 +2,27 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-     "matchPackageNames": ["*"],
-     "enabled": false
+      // Ignore all other packages
+      "matchPackageNames": ["*"],
+      "enabled": false
     },
     {
-      "matchDatasources": ["docker"],
+      // Only update the Serve images used in the charts
       "matchPackageNames": [
         "ghcr.io/scilifelabdatacentre/serve/serve-studio",
         "ghcr.io/scilifelabdatacentre/serve/serve-ingress"
       ],
       "enabled": true,
-      "allowedVersions": "/^develop-\\d{8}$/",
-      "versioning": "docker",
-      "pinDigests": true,
+      // Update both images in the same PR
+      "groupName": "serve images",
+      // Use a regex to extract the version components from the tag, which is in the format "develop-YYYYMMDD"
+      "versioning": "regex:^develop-(?<major>\\d{4})(?<minor>\\d{2})(?<patch>\\d{2})$",
+      "branchName": "update-serve-images-{{newMajor}}-{{newMinor}}-{{newPatch}}",
+      "prTitle": "Update Serve Images to {{newValue}}",
+      "prBody": "Updates Serve images to version {{newValue}} ({{newVersion}})\n\n### Changes\n{{#each updates}}- {{depName}}: `{{currentValue}}` → `{{newValue}}`\n{{/each}}",
       "automerge": false,
-      "schedule": ["* 8-14 * * 1-5"],
+      "schedule": ["* 8-16 * * 1-5"],
+      // Limit to 1 PR at a time to avoid conflicts
       "prConcurrentLimit": 1
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -17,8 +17,8 @@
       "groupName": "serve images",
       // Use a regex to extract the version components from the tag, which is in the format "develop-YYYYMMDD"
       "versioning": "regex:^develop-(?<major>\\d{4})(?<minor>\\d{2})(?<patch>\\d{2})$",
-      "branchName": "update-serve-images-{{newMajor}}-{{newMinor}}-{{newPatch}}",
-      "prTitle": "Update Serve Images to {{newValue}}",
+      "additionalBranchPrefix": "renovate-",
+      "commitMessageTopic": "Update Serve Images to {{newValue}}",
       "prBody": "Updates Serve images to version {{newValue}} ({{newVersion}})\n\n### Changes\n{{#each updates}}- {{depName}}: `{{currentValue}}` → `{{newValue}}`\n{{/each}}",
       "automerge": false,
       "schedule": ["* 8-16 * * 1-5"],


### PR DESCRIPTION
Dry run locally:

```Bash
docker run -e LOG_LEVEL=DEBUG -e LOG_FORMAT=json --rm -v .:/usr/src/app ghcr.io/renovatebot/renovate --platform local
```

The output shows that Renovate detects the latest Serve dev image from 2026. The check will run once a day as scheduled from the JSON.

We will find out more once this is merged :D 