### PR TITLE
Users can add info about their ORCID ID to their profiles

### DIFF
--- a/serve/templates/basic-secrets.yaml
+++ b/serve/templates/basic-secrets.yaml
@@ -40,4 +40,10 @@ data:
   invenio-token: {{ .Values.studio.invenioApiToken | b64enc }}
   {{ end }}
   {{ end }}
+  {{ if .Values.studio.orcid_client_id }}
+  orcid-client-id: {{ .Values.studio.orcid_client_id | b64enc }}
+  {{ end }}
+  {{ if .Values.studio.orcid_client_secret }}
+  orcid-client-secret: {{ .Values.studio.orcid_client_secret | b64enc }}
+  {{ end }}
 {{- end -}}

--- a/serve/templates/studio-deployment.yaml
+++ b/serve/templates/studio-deployment.yaml
@@ -346,6 +346,33 @@ spec:
         - name: INVENIO_API_TOKEN
           value: ""
         {{- end }}
+        {{ if .Values.studio.orcid_client_id }}
+        - name: ORCID_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              {{- if .Values.bitwarden.enabled }}
+              name: serve-bitwarden-secret
+              key: orcid-client-id
+              {{- else }}
+              name: {{ include "studio.secretName" . }}
+              key: orcid-client-id
+              {{- end }}
+        - name: ORCID_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              {{- if .Values.bitwarden.enabled }}
+              name: serve-bitwarden-secret
+              key: orcid-client-secret
+              {{- else }}
+              name: {{ include "studio.secretName" . }}
+              key: orcid-client-secret
+              {{- end }}
+        {{ else }}
+        - name: ORCID_CLIENT_ID
+          value: ""
+        - name: ORCID_CLIENT_SECRET
+          value: ""
+        {{ end }}
         image: {{ .Values.studio.image.repository }}:{{ .Values.studio.image.tag }}
         imagePullPolicy: {{ .Values.studio.image.pullPolicy }}
         name: {{ .Release.Name }}-studio

--- a/serve/templates/studio-settings-configmap.yaml
+++ b/serve/templates/studio-settings-configmap.yaml
@@ -626,3 +626,15 @@ data:
             "TIMEOUT": 7200,
         }
     }
+
+    # ORCID Integration (Public API)
+    # Register credentials at: https://orcid.org/developer-tools (production)
+    # or https://sandbox.orcid.org/developer-tools (sandbox/testing)
+    ORCID_CLIENT_ID = os.environ.get("ORCID_CLIENT_ID", "")
+    ORCID_CLIENT_SECRET = os.environ.get("ORCID_CLIENT_SECRET", "")
+    ORCID_REDIRECT_URI = os.environ.get("ORCID_REDIRECT_URI", f"https://{DOMAIN}/orcid/callback/")
+
+    # For testing use sandbox:  https://sandbox.orcid.org
+    # For production use:       https://orcid.org
+    ORCID_BASE_URL = "https://orcid.org"
+

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -164,6 +164,8 @@ studio:
   invenioEnabled: false
   invenioUrl:
   invenioApiToken:
+  orcid_client_id:
+  orcid_client_secret:
 
 postgresql:
   enabled: true


### PR DESCRIPTION
Users can add info about their ORCID ID to their profiles

For details, see: 

https://scilifelab.atlassian.net/browse/SS-1307

[Also see this document](https://scilifelab.atlassian.net/wiki/spaces/AIportal/pages/4287791122/Integrating+ORCID+authentication+into+Serve+profile)