### PR TITLE
Fix: Update Serve dev image tag

### DIFF
--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -63,7 +63,7 @@ studio:
       type: Recreate
     image:
       repository: ghcr.io/scilifelabdatacentre/serve/serve-ingress
-      tag: develop-20260309
+      tag: develop-20260310
       pullPolicy: Always
     resources:
       limits:
@@ -74,7 +74,7 @@ studio:
         memory: "256Mi"
   image:
     repository: ghcr.io/scilifelabdatacentre/serve/serve-studio
-    tag: develop-20260309
+    tag: develop-20260310
     pullPolicy: Always
   resources:
     limits:


### PR DESCRIPTION
This is usually automated by Renovate which runs once a day but doing this manually to save time.