### PR TITLE
Fix: Refactor IF statement for GitHub token logic

### DIFF
--- a/serve/templates/studio-deployment.yaml
+++ b/serve/templates/studio-deployment.yaml
@@ -139,7 +139,7 @@ spec:
               name: {{ include "studio.redis.secretName" . }}
               key: {{ include "studio.redis.secretPasswordKey" . }}
               {{- end }}
-        {{ if .Values.studio.githubApiToken }}
+        {{ if .Values.studio.githubApiTokenToggle }}
         - name: GITHUB_API_TOKEN
           valueFrom:
             secretKeyRef:

--- a/serve/values-local.example.yaml
+++ b/serve/values-local.example.yaml
@@ -48,6 +48,7 @@ studio:
       mountStudio: false
   emailService:
     enabled: false
+  githubApiTokenToggle:
   dockerhubToken:
   dockerhubUsername:
   invenioEnabled: false

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -158,6 +158,7 @@ studio:
     maxSize: 10
     timeout: 30
     maxIdle: 300
+  githubApiTokenToggle: true
   githubApiToken:
   githubApiUsername:
   dockerhubToken:

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -63,7 +63,7 @@ studio:
       type: Recreate
     image:
       repository: ghcr.io/scilifelabdatacentre/serve/serve-ingress
-      tag: develop-20260310
+      tag: develop-20260311
       pullPolicy: Always
     resources:
       limits:
@@ -74,7 +74,7 @@ studio:
         memory: "256Mi"
   image:
     repository: ghcr.io/scilifelabdatacentre/serve/serve-studio
-    tag: develop-20260310
+    tag: develop-20260311
     pullPolicy: Always
   resources:
     limits:


### PR DESCRIPTION
Container image validation of a `-BAD` image does not work on Serve dev instance. It works on Staging and Prod.

The reason being, this value `.Values.studio.githubApiToken` empty in dev but populated in both Staging and Prod manifests. The [container image check](https://github.com/ScilifelabDataCentre/serve/blob/develop/apps/helpers.py#L782) expects the token to be set to carry out the check. The token is missing from Serve's dev pod.