### PR TITLE
ss-1859 Allow egress from Serve to Invenio

### DIFF
--- a/serve/templates/network-policies.yaml
+++ b/serve/templates/network-policies.yaml
@@ -424,5 +424,23 @@ spec:
         port: 8080
       - protocol: TCP
         port: 9091
+---
+# Allow egress from studio app to invenio namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-from-studio-to-invenio
+  namespace: {{ .Values.namespace | default "default" }}
+spec:
+  podSelector:
+    matchLabels:
+      app: studio-app
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: invenio-dev
 {{- end }}
 {{- end }}

--- a/serve/templates/network-policies.yaml
+++ b/serve/templates/network-policies.yaml
@@ -425,6 +425,7 @@ spec:
       - protocol: TCP
         port: 9091
 ---
+{{- end }}
 # Allow egress from studio app to invenio namespace
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -441,6 +442,5 @@ spec:
   - to:
     - namespaceSelector:
         matchLabels:
-          kubernetes.io/metadata.name: invenio-dev
-{{- end }}
+          kubernetes.io/metadata.name: {{ .Values.networkPolicy.invenio_namespace | default "invenio-dev" }}
 {{- end }}

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -278,6 +278,7 @@ networkPolicy:
     - 192.168.0.0/16
     - 172.0.0.0/20
   ingress_controller_namespace: kube-system
+  invenio_namespace: invenio-dev
 
 serviceAccount:
   create: true


### PR DESCRIPTION
Serve has a default network policy set to deny all egress. This PR aims to allow cross-namespace communication between Serve and Invenio by creating a policy that allows egress from Serve to the Invenio namespace.

These changes will be accompanied by [changes](https://github.com/ScilifelabDataCentre/serve-invenio/pull/18) in our Invenio charts to add the service FQDN as a trusted host.

Jira: https://scilifelab.atlassian.net/browse/SS-1859