### PR TITLE
ss-1952 Add support for client max body size on HTTPRoutes

### DIFF
--- a/apps/common/templates/_httproute.tpl
+++ b/apps/common/templates/_httproute.tpl
@@ -76,6 +76,27 @@ spec:
 {{- end }}
 
 {{/*
+ClientSettingsPolicy for body size limit on the app's HTTPRoute.
+Usage: {{ include "common.clientSettingsPolicy" . }}
+*/}}
+{{- define "common.clientSettingsPolicy" -}}
+{{- if and .Values.gateway.enabled .Values.ingress.clientMaxBodySize }}
+apiVersion: gateway.nginx.org/v1alpha1
+kind: ClientSettingsPolicy
+metadata:
+  name: {{ .Release.Name }}-client-settings
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: {{ .Release.Name }}-httproute
+  body:
+    maxSize: "{{ .Values.ingress.clientMaxBodySize | lower }}"
+{{- end }}
+{{- end }}
+
+{{/*
 RateLimitPolicy targeting the app's HTTPRoute.
 Usage: {{ include "common.rateLimitPolicy" . }}
 */}}

--- a/apps/custom-app/templates/clientsettingspolicy.yaml
+++ b/apps/custom-app/templates/clientsettingspolicy.yaml
@@ -1,0 +1,1 @@
+{{- include "common.clientSettingsPolicy" . }}

--- a/apps/dash/templates/clientsettingspolicy.yaml
+++ b/apps/dash/templates/clientsettingspolicy.yaml
@@ -1,0 +1,1 @@
+{{- include "common.clientSettingsPolicy" . }}

--- a/apps/filemanager/templates/clientsettingspolicy.yaml
+++ b/apps/filemanager/templates/clientsettingspolicy.yaml
@@ -1,0 +1,1 @@
+{{- include "common.clientSettingsPolicy" . }}

--- a/apps/filemanager/values.yaml
+++ b/apps/filemanager/values.yaml
@@ -12,7 +12,7 @@ global:
 
 ingress:
   secretName: prod-ingress
-  clientMaxBodySize: 10000M
+  clientMaxBodySize: 10g
 
 gateway:
   enabled: true

--- a/apps/jupyter-lab/templates/clientsettingspolicy.yaml
+++ b/apps/jupyter-lab/templates/clientsettingspolicy.yaml
@@ -1,0 +1,1 @@
+{{- include "common.clientSettingsPolicy" . }}

--- a/apps/rstudio/templates/clientsettingspolicy.yaml
+++ b/apps/rstudio/templates/clientsettingspolicy.yaml
@@ -1,0 +1,1 @@
+{{- include "common.clientSettingsPolicy" . }}

--- a/apps/shiny/templates/clientsettingspolicy.yaml
+++ b/apps/shiny/templates/clientsettingspolicy.yaml
@@ -1,0 +1,1 @@
+{{- include "common.clientSettingsPolicy" . }}

--- a/apps/shinyproxy/templates/clientsettingspolicy.yaml
+++ b/apps/shinyproxy/templates/clientsettingspolicy.yaml
@@ -1,0 +1,1 @@
+{{- include "common.clientSettingsPolicy" . }}

--- a/apps/tissuumaps/templates/clientsettingspolicy.yaml
+++ b/apps/tissuumaps/templates/clientsettingspolicy.yaml
@@ -1,0 +1,1 @@
+{{- include "common.clientSettingsPolicy" . }}

--- a/apps/vscode/templates/clientsettingspolicy.yaml
+++ b/apps/vscode/templates/clientsettingspolicy.yaml
@@ -1,0 +1,1 @@
+{{- include "common.clientSettingsPolicy" . }}

--- a/serve/templates/role.yaml
+++ b/serve/templates/role.yaml
@@ -19,7 +19,7 @@ rules:
     resources: ["httproutes"]
     verbs: ["*"]
   - apiGroups: ["gateway.nginx.org"]
-    resources: ["snippetsfilters", "ratelimitpolicies"]
+    resources: ["snippetsfilters", "ratelimitpolicies", "clientsettingspolicies"]
     verbs: ["*"]
 {{- end }}
 ---

--- a/serve/values-local.example.yaml
+++ b/serve/values-local.example.yaml
@@ -127,6 +127,7 @@ gateway:
   port: 80
   domain: studio.127.0.0.1.nip.io
   sectionName: serve-dev-subdomains
+  studioSectionName: http
   whitelistingSnippetsFilter:
     enabled: false
     # IP ranges allowed to access admin endpoints


### PR DESCRIPTION
Jira: https://scilifelab.atlassian.net/browse/SS-1952

Introduce a `ClientSettingsPolicy` for client max body size on HTTPRoutes of Serve apps.
This is meant to replace the ingress annotation `nginx.ingress.kubernetes.io/proxy-body-size`

## TODO

- [x] Check that the changes work locally with Helm
- [x] Check that the changes work on Serve dev