### PR TITLE
SS-1936 add gpu capacity check settings

### DIFF
--- a/serve/templates/studio-settings-configmap.yaml
+++ b/serve/templates/studio-settings-configmap.yaml
@@ -470,6 +470,7 @@ data:
     GPU_TOTAL_CAPACITY = int(os.environ.get("GPU_TOTAL_CAPACITY", "{{ .Values.studio.gpu_total_capacity | default 0 }}"))
     DEVELOP_APP_MAX_AGE_DAYS = int(os.environ.get("DEVELOP_APP_MAX_AGE_DAYS", "{{ .Values.studio.develop_app_max_age_days | default 7 }}"))
     GPU_DEVELOP_APP_MAX_AGE_DAYS = int(os.environ.get("GPU_DEVELOP_APP_MAX_AGE_DAYS", "{{ .Values.studio.gpu_develop_app_max_age_days | default 1 }}"))
+    FILEMANAGER_MAX_AGE_DAYS = int(os.environ.get("FILEMANAGER_MAX_AGE_DAYS", "{{ .Values.studio.filemanager_max_age_days | default 1 }}"))
 
     # Email
     DEFAULT_FROM_EMAIL = "noreply-serve@scilifelab.se"

--- a/serve/templates/studio-settings-configmap.yaml
+++ b/serve/templates/studio-settings-configmap.yaml
@@ -468,6 +468,8 @@ data:
     SESSION_COOKIE_DOMAIN = {{ .Values.studio.session_cookie_domain | quote }}
     CSRF_TRUSTED_ORIGINS = ['https://*{{ .Values.studio.session_cookie_domain }}','https://*.127.0.0.1'] + [{{ .Values.studio.csrf_trusted_origins | quote}}]
     GPU_TOTAL_CAPACITY = int(os.environ.get("GPU_TOTAL_CAPACITY", "{{ .Values.studio.gpu_total_capacity | default 0 }}"))
+    DEVELOP_APP_MAX_AGE_DAYS = int(os.environ.get("DEVELOP_APP_MAX_AGE_DAYS", "{{ .Values.studio.develop_app_max_age_days | default 7 }}"))
+    GPU_DEVELOP_APP_MAX_AGE_DAYS = int(os.environ.get("GPU_DEVELOP_APP_MAX_AGE_DAYS", "{{ .Values.studio.gpu_develop_app_max_age_days | default 1 }}"))
 
     # Email
     DEFAULT_FROM_EMAIL = "noreply-serve@scilifelab.se"

--- a/serve/templates/studio-settings-configmap.yaml
+++ b/serve/templates/studio-settings-configmap.yaml
@@ -467,6 +467,7 @@ data:
     # To enable sticky sessions for k8s ingress
     SESSION_COOKIE_DOMAIN = {{ .Values.studio.session_cookie_domain | quote }}
     CSRF_TRUSTED_ORIGINS = ['https://*{{ .Values.studio.session_cookie_domain }}','https://*.127.0.0.1'] + [{{ .Values.studio.csrf_trusted_origins | quote}}]
+    GPU_TOTAL_CAPACITY = int(os.environ.get("GPU_TOTAL_CAPACITY", "{{ .Values.studio.gpu_total_capacity | default 0 }}"))
 
     # Email
     DEFAULT_FROM_EMAIL = "noreply-serve@scilifelab.se"

--- a/serve/values-local.example.yaml
+++ b/serve/values-local.example.yaml
@@ -18,6 +18,7 @@ studio:
   domain: studio.127.0.0.1.nip.io
   session_cookie_domain: .127.0.0.1.nip.io
   superuserPassword: "yourpassword"
+  gpu_total_capacity: 0
   superuserEmail: "your.email@example.com"
   djangoAdminUrlPath: "admin"
   storageClass: *storage_class

--- a/serve/values-local.example.yaml
+++ b/serve/values-local.example.yaml
@@ -19,6 +19,8 @@ studio:
   session_cookie_domain: .127.0.0.1.nip.io
   superuserPassword: "yourpassword"
   gpu_total_capacity: 0
+  develop_app_max_age_days: 7
+  gpu_develop_app_max_age_days: 1
   superuserEmail: "your.email@example.com"
   djangoAdminUrlPath: "admin"
   storageClass: *storage_class

--- a/serve/values-local.example.yaml
+++ b/serve/values-local.example.yaml
@@ -21,6 +21,7 @@ studio:
   gpu_total_capacity: 0
   develop_app_max_age_days: 7
   gpu_develop_app_max_age_days: 1
+  filemanager_max_age_days: 1
   superuserEmail: "your.email@example.com"
   djangoAdminUrlPath: "admin"
   storageClass: *storage_class

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -43,6 +43,7 @@ studio:
   gpu_total_capacity: 0
   develop_app_max_age_days: 7
   gpu_develop_app_max_age_days: 1
+  filemanager_max_age_days: 1
   custom_migrations:
     enabled: false
     apps:

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -40,6 +40,7 @@ studio:
     - "common"
   domain: serve-dev.scilifelab.se
   session_cookie_domain: .serve-dev.scilifelab.se
+  gpu_total_capacity: 0
   custom_migrations:
     enabled: false
     apps:

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -41,6 +41,8 @@ studio:
   domain: serve-dev.scilifelab.se
   session_cookie_domain: .serve-dev.scilifelab.se
   gpu_total_capacity: 0
+  develop_app_max_age_days: 7
+  gpu_develop_app_max_age_days: 1
   custom_migrations:
     enabled: false
     apps:


### PR DESCRIPTION
## Description

This PR relates to [SS-1936](https://scilifelab.atlassian.net/browse/SS-1936) and supports the GPU scheduling changes in Serve.

It adds the new GPU capacity setting to the Serve Helm chart so deployed environments can configure how many GPUs are available for user apps.

- Adds `GPU_TOTAL_CAPACITY` to the rendered `studio-settings-configmap.yaml`.
- Exposes the value as `studio.gpu_total_capacity`.
- Defaults GPU capacity to `0` in both `values.yaml` and `values-local.example.yaml`, so GPU app scheduling is opt-in per environment.