### PR TITLE
ss-1945 Changes to run Depictio with Gateway API

### DIFF
--- a/serve/templates/_helper.tpl
+++ b/serve/templates/_helper.tpl
@@ -477,12 +477,4 @@ Studio container environment variables
       {{- end }}
 - name: DOI_PREFIX
   value: {{ .Values.studio.doiPrefix | quote }}
-- name: GATEWAY_ENABLED
-  value: {{ .Values.gateway.enabled | default false | quote }}
-- name: GATEWAY_NAME
-  value: {{ .Values.gateway.name | default "" | quote }}
-- name: GATEWAY_NAMESPACE
-  value: {{ .Values.gateway.namespace | default "" | quote }}
-- name: GATEWAY_SECTION_NAME
-  value: {{ .Values.gateway.sectionName | default "" | quote }}
 {{- end -}}

--- a/serve/templates/_helper.tpl
+++ b/serve/templates/_helper.tpl
@@ -477,4 +477,12 @@ Studio container environment variables
       {{- end }}
 - name: DOI_PREFIX
   value: {{ .Values.studio.doiPrefix | quote }}
+- name: GATEWAY_ENABLED
+  value: {{ .Values.gateway.enabled | default false | quote }}
+- name: GATEWAY_NAME
+  value: {{ .Values.gateway.name | default "" | quote }}
+- name: GATEWAY_NAMESPACE
+  value: {{ .Values.gateway.namespace | default "" | quote }}
+- name: GATEWAY_SECTION_NAME
+  value: {{ .Values.gateway.sectionName | default "" | quote }}
 {{- end -}}

--- a/serve/templates/studio-settings-configmap.yaml
+++ b/serve/templates/studio-settings-configmap.yaml
@@ -418,6 +418,11 @@ data:
     NAMESPACE = {{ .Values.namespace | default "default" | quote }}
     KUBE_API_REQUEST_TIMEOUT = {{ .Values.studio.kube_api_request_timeout }}
     STORAGECLASS = {{ include "studio.storageclass" . | quote }}
+    GATEWAY_ENABLED = {{ if .Values.gateway.enabled }}True{{ else }}False{{ end }}
+    GATEWAY_NAME = os.getenv("GATEWAY_NAME", "{{ .Values.gateway.name }}")
+    GATEWAY_NAMESPACE = os.getenv("GATEWAY_NAMESPACE", "{{ .Values.gateway.namespace }}")
+    GATEWAY_SECTION_NAME = os.getenv("GATEWAY_SECTION_NAME", "{{ .Values.gateway.sectionName }}")
+    GATEWAY_PORT = int(os.getenv("GATEWAY_PORT", "{{ .Values.gateway.port | default 80 }}"))
     
     # App dependencies
 


### PR DESCRIPTION
Updating the `settings.py` configmap following changes introduced in this [PR](https://github.com/ScilifelabDataCentre/serve/pull/554).

## TODO

- [x] Only merge this PR after Serve's v5.1.0-beta release