### PR TITLE
SS-1980 Pooling stats logging for celery workers

### DIFF
--- a/serve/templates/celery-beat-deployment.yaml
+++ b/serve/templates/celery-beat-deployment.yaml
@@ -67,6 +67,14 @@ spec:
         env:
         - name: BASE_PATH
           value: "/app"
+        - name: DB_POOL_MIN_SIZE
+          value: {{ .Values.celeryBeat.connectionPool.minSize | default 0 | quote }}
+        - name: DB_POOL_MAX_SIZE
+          value: {{ .Values.celeryBeat.connectionPool.maxSize | default 1 | quote }}
+        - name: DB_POOL_TIMEOUT
+          value: {{ .Values.celeryBeat.connectionPool.timeout | default .Values.studio.connectionPool.timeout | default 30 | quote }}
+        - name: DB_POOL_MAX_IDLE
+          value: {{ .Values.celeryBeat.connectionPool.maxIdle | default 60 | quote }}
         {{- include "studio.env" . | nindent 8 }}
         image: {{ .Values.studio.image.repository }}:{{ .Values.studio.image.tag }}
         imagePullPolicy: {{ .Values.studio.image.pullPolicy }}

--- a/serve/templates/celery-worker-deployment.yaml
+++ b/serve/templates/celery-worker-deployment.yaml
@@ -68,6 +68,14 @@ spec:
           value: "/app"
         - name: CELERY_CONCURRENCY
           value: {{ .Values.celeryWorkers.concurrency | default 4 | quote }}
+        - name: DB_POOL_MIN_SIZE
+          value: {{ .Values.celeryWorkers.connectionPool.minSize | default 0 | quote }}
+        - name: DB_POOL_MAX_SIZE
+          value: {{ .Values.celeryWorkers.connectionPool.maxSize | default 2 | quote }}
+        - name: DB_POOL_TIMEOUT
+          value: {{ .Values.celeryWorkers.connectionPool.timeout | default .Values.studio.connectionPool.timeout | default 30 | quote }}
+        - name: DB_POOL_MAX_IDLE
+          value: {{ .Values.celeryWorkers.connectionPool.maxIdle | default 60 | quote }}
         {{- include "studio.env" . | nindent 8 }}
         image: {{ .Values.studio.image.repository }}:{{ .Values.studio.image.tag }}
         imagePullPolicy: {{ .Values.studio.image.pullPolicy }}

--- a/serve/templates/celery-worker-deployment.yaml
+++ b/serve/templates/celery-worker-deployment.yaml
@@ -19,6 +19,11 @@ spec:
       annotations:
         kompose.cmd: kompose convert
         kompose.version: 1.20.0 ()
+        {{- if .Values.celeryWorkers.metrics.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: {{ .Values.celeryWorkers.metrics.port | default 8001 | quote }}
+        {{- end }}
       creationTimestamp: null
       labels:
         io.kompose.service: {{ .Release.Name }}-celery-worker
@@ -76,10 +81,21 @@ spec:
           value: {{ .Values.celeryWorkers.connectionPool.timeout | default .Values.studio.connectionPool.timeout | default 30 | quote }}
         - name: DB_POOL_MAX_IDLE
           value: {{ .Values.celeryWorkers.connectionPool.maxIdle | default 60 | quote }}
+        {{- if .Values.celeryWorkers.metrics.enabled }}
+        - name: PROMETHEUS_MULTIPROC_DIR
+          value: /tmp/prometheus
+        - name: CELERY_METRICS_PORT
+          value: {{ .Values.celeryWorkers.metrics.port | default 8001 | quote }}
+        {{- end }}
         {{- include "studio.env" . | nindent 8 }}
         image: {{ .Values.studio.image.repository }}:{{ .Values.studio.image.tag }}
         imagePullPolicy: {{ .Values.studio.image.pullPolicy }}
         name: {{ .Release.Name }}-celery-worker
+        {{- if .Values.celeryWorkers.metrics.enabled }}
+        ports:
+        - containerPort: {{ .Values.celeryWorkers.metrics.port | default 8001 }}
+          name: metrics
+        {{- end }}
         resources:
           limits:
             cpu: {{ .Values.celeryWorkers.resources.limits.cpu }}
@@ -96,12 +112,20 @@ spec:
           - mountPath: /app/studio/settings.py
             subPath: settings.py
             name: {{ .Release.Name}}-settings-configmap
+          {{- if .Values.celeryWorkers.metrics.enabled }}
+          - mountPath: /tmp/prometheus
+            name: prometheus-multiproc
+          {{- end }}
       restartPolicy: Always
       volumes:
       {{- if .Values.chartcontroller.addSecret }}
       - name: config
         secret:
           secretName: {{ .Release.Name }}-chart-controller-secret
+      {{- end }}
+      {{- if .Values.celeryWorkers.metrics.enabled }}
+      - name: prometheus-multiproc
+        emptyDir: {}
       {{- end }}
       - name: {{ .Release.Name}}-settings-configmap
         configMap:

--- a/serve/templates/studio-settings-configmap.yaml
+++ b/serve/templates/studio-settings-configmap.yaml
@@ -176,6 +176,10 @@ data:
     AUTH_RATE_LIMIT_WHITELIST_RAW = {{ .Values.studio.rateLimit.authEndpoint.whitelist | default "" | quote }}
     AUTH_RATE_LIMIT_WHITELIST = [ip.strip() for ip in AUTH_RATE_LIMIT_WHITELIST_RAW.split(",")]
     DB_POOL_STATS_LOGGING_ENABLED = {{ if .Values.studio.connectionPool.dbPoolStatsLogging }}True{{ else }}False{{ end }}
+    DB_POOL_MIN_SIZE = int(os.getenv("DB_POOL_MIN_SIZE", "{{ .Values.studio.connectionPool.minSize | default 4 }}"))
+    DB_POOL_MAX_SIZE = int(os.getenv("DB_POOL_MAX_SIZE", "{{ .Values.studio.connectionPool.maxSize | default 10 }}"))
+    DB_POOL_TIMEOUT = int(os.getenv("DB_POOL_TIMEOUT", "{{ .Values.studio.connectionPool.timeout | default 30 }}"))
+    DB_POOL_MAX_IDLE = int(os.getenv("DB_POOL_MAX_IDLE", "{{ .Values.studio.connectionPool.maxIdle | default 300 }}"))
     PROMETHEUS_METRICS_ENABLED = {{ if .Values.studio.metrics.enabled }}True{{ else }}False{{ end }}
     AUTH_PERMISSION_CACHE_ENABLED = {{ if .Values.studio.authPermissionCache.enabled }}True{{ else }}False{{ end }}
     AUTH_PERMISSION_CACHE_TIMEOUT = {{ .Values.studio.authPermissionCache.timeout | default 30 }}
@@ -284,6 +288,15 @@ data:
         return " ".join(options)
 
 
+    def log_db_pool_reconnect_failed(pool: object) -> None:
+        stats = pool.get_stats() if hasattr(pool, "get_stats") else {}
+        logging.getLogger("psycopg_pool").error(
+            "Django DB pool reconnect failed pool_name=%s stats=%s",
+            getattr(pool, "name", None),
+            stats,
+        )
+
+
     DATABASES = {
         'default': {
             "ENGINE": "django.db.backends.postgresql",
@@ -296,10 +309,11 @@ data:
                 "options": postgres_session_options(),
                 {{ if .Values.studio.connectionPool.enabled }}
                 "pool": {
-                    "min_size": {{ .Values.studio.connectionPool.minSize | default 4 }},
-                    "max_size": {{ .Values.studio.connectionPool.maxSize | default 10 }},
-                    "timeout": {{ .Values.studio.connectionPool.timeout | default 30 }},
-                    "max_idle": {{ .Values.studio.connectionPool.maxIdle | default 300 }},
+                    "min_size": DB_POOL_MIN_SIZE,
+                    "max_size": DB_POOL_MAX_SIZE,
+                    "timeout": DB_POOL_TIMEOUT,
+                    "max_idle": DB_POOL_MAX_IDLE,
+                    "reconnect_failed": log_db_pool_reconnect_failed,
                 },
                 {{ end }}
             },
@@ -415,6 +429,7 @@ data:
     CELERY_ACCEPT_CONTENT = ['json']
     CELERY_TIMEZONE = "UTC"
     CELERY_ENABLE_UTC = True
+    CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
     # For Model Objects creation (check models/models.py, pre_save_model() )
     VERSION_BACKEND = 'studio.version.Version'
 
@@ -627,6 +642,11 @@ data:
             "django.server": {
                 "handlers": ["console" if DEVELOP_LOGS_ENABLED else "json"],
                 "level": "WARNING",
+                "propagate": False,
+            },
+            "psycopg_pool": {
+                "handlers": ["console" if DEVELOP_LOGS_ENABLED else "json"],
+                "level": os.getenv("PSYCOPG_POOL_LOG_LEVEL", "WARNING"),
                 "propagate": False,
             },
         },

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -279,6 +279,9 @@ rabbitmq:
 celeryWorkers:
   replicas: 2
   concurrency: 4
+  metrics:
+    enabled: true
+    port: 8001
   connectionPool:
     minSize: 0
     maxSize: 2

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -222,6 +222,11 @@ postgresql:
     extraEnvVars:
       - name: POSTGRESQL_MAX_CONNECTIONS
         value: "300"
+    extendedConfiguration: |-
+      log_connections = on
+      log_disconnections = on
+      log_lock_waits = on
+      log_min_error_statement = error
     persistence:
       enabled: true
       size: "10Gi"
@@ -274,6 +279,11 @@ rabbitmq:
 celeryWorkers:
   replicas: 2
   concurrency: 4
+  connectionPool:
+    minSize: 0
+    maxSize: 2
+    timeout: 30
+    maxIdle: 60
   resources:
     requests:
       cpu: "100m"
@@ -281,6 +291,13 @@ celeryWorkers:
     limits:
       cpu: "1000m"
       memory: "8Gi"
+
+celeryBeat:
+  connectionPool:
+    minSize: 0
+    maxSize: 1
+    timeout: 30
+    maxIdle: 60
 
 celeryFlower:
   enabled: false


### PR DESCRIPTION
This PR relates to [SS-1980](https://scilifelab.atlassian.net/browse/SS-1980).

Adds more visibility to Django/Postgres connection pool behavior, especially for Celery workers where the pool timeout errors have been hard to diagnose.
- Makes DB pool sizing configurable with `DB_POOL_*` environment variables
- Adds matching chart settings so web, Celery worker, and Celery beat pods can use different pool sizes.
- Adds PostgreSQL logging for connections, disconnections, lock waits, and error statements in Serve charts.