### PR TITLE
ss-1981 Remove comments from Renovate's JSON config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,27 +2,22 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      // Ignore all other packages
       "matchPackageNames": ["*"],
       "enabled": false
     },
     {
-      // Only update the Serve images used in the charts
       "matchPackageNames": [
         "ghcr.io/scilifelabdatacentre/serve/serve-studio",
         "ghcr.io/scilifelabdatacentre/serve/serve-ingress"
       ],
       "enabled": true,
-      // Update both images in the same PR
       "groupName": "serve images",
-      // Use a regex to extract the version components from the tag, which is in the format "develop-YYYYMMDD"
       "versioning": "regex:^develop-(?<major>\\d{4})(?<minor>\\d{2})(?<patch>\\d{2})$",
       "additionalBranchPrefix": "renovate-",
       "commitMessageTopic": "Update Serve Images to {{newValue}}",
       "prBody": "Updates Serve images to version {{newValue}} ({{newVersion}})\n\n### Changes\n{{#each updates}}- {{depName}}: `{{currentValue}}` → `{{newValue}}`\n{{/each}}",
       "automerge": false,
       "schedule": ["* 8-16 * * 1-5"],
-      // Limit to 1 PR at a time to avoid conflicts
       "prConcurrentLimit": 1
     }
   ]


### PR DESCRIPTION
Jira: https://scilifelab.atlassian.net/browse/SS-1981

Renovate is not crashing but it is not active in this repo as it should. We suspect that’s because of comments in the JSON file. Even though this same config was previously working fine, we will remove those comments for now.