### PR TITLE
ss-1985 Remove schedule parameter from Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,6 @@
       "commitMessageTopic": "Update Serve Images to {{newValue}}",
       "prBody": "Updates Serve images to version {{newValue}} ({{newVersion}})\n\n### Changes\n{{#each updates}}- {{depName}}: `{{currentValue}}` → `{{newValue}}`\n{{/each}}",
       "automerge": false,
-      "schedule": ["* 8-16 * * 1-5"],
       "prConcurrentLimit": 1
     }
   ]


### PR DESCRIPTION
Jira: https://scilifelab.atlassian.net/browse/SS-1985

The defined schedule in `renovate.json` might be clashing with Renovate's scheduled run.