### PR TITLE
ss-1986 Add a ParentRef to Serve's HTTPRoute

### DIFF
--- a/serve/templates/httproute.yaml
+++ b/serve/templates/httproute.yaml
@@ -9,6 +9,14 @@ spec:
   - {{ .Values.gateway.domain | quote }}
   - "gw.{{ .Values.gateway.domain }}"
   parentRefs:
+  {{- if .Values.gateway.domainSectionName }}
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ .Values.gateway.name | default "default" }}
+    namespace: {{ .Values.gateway.namespace | default "gateway" }}
+    sectionName: {{ .Values.gateway.domainSectionName }}
+    port: {{ .Values.gateway.port | default (eq .Values.environment "vscode" | ternary 80 443) }}
+  {{- end }}
   - group: gateway.networking.k8s.io
     kind: Gateway
     name: {{ .Values.gateway.name | default "default" }}

--- a/serve/values-local.example.yaml
+++ b/serve/values-local.example.yaml
@@ -152,6 +152,7 @@ gateway:
   gatewayClassName: nginx
   port: 80
   domain: studio.127.0.0.1.nip.io
+  domainSectionName:
   sectionName: serve-dev-subdomains
   studioSectionName: http
   whitelistingSnippetsFilter:

--- a/serve/values.yaml
+++ b/serve/values.yaml
@@ -367,6 +367,7 @@ gateway:
   gatewayClassName: nginx
   port: 443
   domain: serve-dev.scilifelab.se
+  domainSectionName: serve-dev
   sectionName: serve-dev-subdomains
   studioSectionName: serve-dev-subdomains
   whitelistingSnippetsFilter:


### PR DESCRIPTION
Jira: https://scilifelab.atlassian.net/browse/SS-1986

Add another ParentRef to Serve's HTTPRoute to bind it to the apex domain listener on the Gateway. This became apparent when we switched over to Gateway API on the cluster after having used Serve's domain with a `.gw` prefix prior to that.

- [x] Works locally