### PR TITLE
ss-1987 Use correct tissuumaps container image

### DIFF
--- a/apps/tissuumaps/values.yaml
+++ b/apps/tissuumaps/values.yaml
@@ -13,7 +13,7 @@ apps:
   volumeK8s:
 
 appconfig:
-  image: ghcr.io/scilifelabdatacentre/tissuumaps:3
+  image: docker.io/cavenel/tissuumaps:3
   path: /mnt/data/
 
 service:


### PR DESCRIPTION
Jira: https://scilifelab.atlassian.net/browse/SS-1987

When running the integration tests, I noticed that the tissuumaps app was showing an image pull error because the image does not exist. I’m not sure why the image was recently changed (by me!) so I will revert it back to the image that works.

I have not changed the chart version because I am just reverting back to the correct image.