### PR TITLE
SS-1991 Update charts to allow larger uploads

### DIFF
--- a/apps/common/Chart.yaml
+++ b/apps/common/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: common
-version: 0.1.0
+version: 0.1.1
 type: library
 description: Shared Helm templates for serve app charts
 maintainers:

--- a/apps/common/templates/_httproute.tpl
+++ b/apps/common/templates/_httproute.tpl
@@ -63,6 +63,9 @@ spec:
     value: |
       location /auth/ {
         internal;
+{{- with .Values.ingress.clientMaxBodySize }}
+        client_max_body_size {{ . | lower }};
+{{- end }}
         resolver 10.43.0.10;
         proxy_pass {{ .Values.global.protocol | lower }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release | default .Release.Name }};
         proxy_pass_request_body off;

--- a/apps/custom-app/Chart.yaml
+++ b/apps/custom-app/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 appVersion: "0.1"
 description: A Helm chart for a standard serve app
 name: custom-app
-version: 1.1.6
+version: 1.1.7
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se
 dependencies:
   - name: common
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../common"

--- a/apps/dash/Chart.yaml
+++ b/apps/dash/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 appVersion: "0.1"
 description: A Helm chart Dash apps
 name: dash-app
-version: 1.0.7
+version: 1.0.8
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se
 dependencies:
   - name: common
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../common"

--- a/apps/filemanager/Chart.yaml
+++ b/apps/filemanager/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 appVersion: "0.1"
 description: A Helm chart for the serve File Manager
 name: filemanager
-version: 1.0.8
+version: 1.0.9
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se
 dependencies:
   - name: common
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../common"

--- a/apps/jupyter-lab/Chart.yaml
+++ b/apps/jupyter-lab/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 appVersion: "0.1"
 description: A Helm chart for Jupyter Lab
 name: lab
-version: 1.0.9
+version: 1.0.10
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se
 dependencies:
   - name: common
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../common"

--- a/apps/rstudio/Chart.yaml
+++ b/apps/rstudio/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 appVersion: "0.1"
 description: A Helm chart for RStudio in the browser
 name: rstudio
-version: 1.0.8
+version: 1.0.9
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se
 dependencies:
   - name: common
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../common"

--- a/apps/shiny/Chart.yaml
+++ b/apps/shiny/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 appVersion: "0.1"
 description: A Helm chart Shiny apps
 name: shinyapp
-version: 1.0.8
+version: 1.0.9
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se
 dependencies:
   - name: common
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../common"

--- a/apps/shinyproxy/Chart.yaml
+++ b/apps/shinyproxy/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: shinyproxy
 description: A Helm chart to install Shinyproxy
 type: application
-version: 1.4.9
+version: 1.4.10
 appVersion: "0.1"
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se
 dependencies:
   - name: common
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../common"

--- a/apps/tissuumaps/Chart.yaml
+++ b/apps/tissuumaps/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 appVersion: "0.1"
 description: A Helm chart tissuumaps apps
 name: tissuumaps
-version: 1.0.7
+version: 1.0.8
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se
 dependencies:
   - name: common
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../common"

--- a/apps/vscode/Chart.yaml
+++ b/apps/vscode/Chart.yaml
@@ -3,11 +3,11 @@ apiVersion: v2
 appVersion: "0.1"
 description: A Helm chart for VS code in the browser
 name: vscode
-version: 1.0.7
+version: 1.0.8
 maintainers:
   - name: Team Whale
     email: serve@scilifelab.se
 dependencies:
   - name: common
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../common"


### PR DESCRIPTION
## Description

This PR relates to [SS-1991](https://scilifelab.atlassian.net/browse/SS-1991).

This fixes uploads larger than 1 MB for protected applications routed through NGINX Gateway Fabric.

The existing `ClientSettingsPolicy` correctly raises the limit on the application route, but the internal `/auth/` subrequest retained NGINX’s 1 MB default.

- Applies `ingress.clientMaxBodySize` inside the shared `/auth/` location.
- Bumps the common library chart to `0.1.1`.
- Publishes new versions of the following charts:
  - `custom-app:1.1.7`
  - `dash-app:1.0.8`
  - `filemanager:1.0.9`
  - `lab:1.0.10`
  - `rstudio:1.0.9`
  - `shinyapp:1.0.9`
  - `shinyproxy:1.4.10`
  - `tissuumaps:1.0.8`
  - `vscode:1.0.8`