### PR TITLE
SS-1433 Harden shinyproxy pre-delete hook

### DIFF
--- a/apps/shinyproxy/Chart.yaml
+++ b/apps/shinyproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: shinyproxy
 description: A Helm chart to install Shinyproxy
 type: application
-version: 1.4.10
+version: 1.4.11
 appVersion: "0.1"
 maintainers:
   - name: Team Whale

--- a/apps/shinyproxy/templates/hooks.yaml
+++ b/apps/shinyproxy/templates/hooks.yaml
@@ -7,8 +7,10 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  backoffLimit: {{ .Values.hooks.deleteUserPods.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.hooks.deleteUserPods.activeDeadlineSeconds }}
   template:
     metadata:
       name: "delete-user-pods-{{ .Release.Name }}"
@@ -20,7 +22,7 @@ spec:
       serviceAccountName: {{ .Release.Namespace }}-shinyproxy
       containers:
       - name: delete-user-pods
-        image: bitnamilegacy/kubectl:{{ .Capabilities.KubeVersion.Major }}.{{ .Capabilities.KubeVersion.Minor }}
+        image: {{ .Values.hooks.deleteUserPods.image }}
         args:
           - "delete"
           - "pods"

--- a/apps/shinyproxy/values.yaml
+++ b/apps/shinyproxy/values.yaml
@@ -55,6 +55,12 @@ gateway:
 s3sync:
   image: scaleoutsystems/s3-sync:latest
 
+hooks:
+  deleteUserPods:
+    image: registry.k8s.io/kubectl:v1.33.4
+    backoffLimit: 0
+    activeDeadlineSeconds: 60
+
 podSecurityContext:
   seccompProfile:
     type: RuntimeDefault


### PR DESCRIPTION
## Description

Relates to [SS-1433](https://scilifelab.atlassian.net/browse/SS-1433).

The shinyproxy pre-delete hook pulls `bitnamilegacy/kubectl:{{ .Capabilities.KubeVersion.Major }}.{{ .Capabilities.KubeVersion.Minor }}`. That tag is rendered from the live cluster version, and Bitnami's archived namespace stops at 1.33 and `bitnamilegacy/kubectl:1.34` and `:1.35` are both not found. Our cluster is on 1.33, so it works today, but the next cluster upgrade renders an image that cannot be pulled. Helm runs pre-delete hooks from the stored release manifest, so already-installed releases keep `1.33`. 

- Pin the hook image via values to `registry.k8s.io/kubectl:v1.33.4`, which the Kubernetes project publishes and maintains.

- Add `before-hook-creation` to the hook delete policy. With only `hook-succeeded`, a failed hook Job is retained, so the next uninstall hits `AlreadyExists` and the release becomes permanently un-uninstallable.

Chart version bumped 1.4.10 → 1.4.11.